### PR TITLE
fix(auth): unify post-sign-in redirect with callback flow

### DIFF
--- a/src/auth/AuthPage.tsx
+++ b/src/auth/AuthPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { AuthForm } from './AuthForm';
 import { PasswordReset } from './PasswordReset';
+import { getPostAuthStudioUrl } from '../routing/hostRouting';
 
 type AuthMode = 'signin' | 'signup' | 'reset';
 
@@ -11,8 +12,11 @@ export const AuthPage = () => {
 
   const handleAuthSuccess = () => {
     const redirect = searchParams.get('redirect');
-    const target = redirect && redirect.startsWith('/') ? redirect : '/';
-    window.location.href = target;
+    const safeRedirect = redirect && redirect.startsWith('/') ? redirect : undefined;
+    const target = safeRedirect
+      ? getPostAuthStudioUrl(`redirect=${encodeURIComponent(safeRedirect)}`)
+      : getPostAuthStudioUrl();
+    window.location.replace(target);
   };
 
   return (


### PR DESCRIPTION
Route form sign-in success through the same host-aware studio destination logic used by auth callbacks so production users land on the app subdomain instead of marketing root.
