### PR TITLE
Scope saved sessions and demo state per account in localStorage

### DIFF
--- a/src/context/RecordingContext.tsx
+++ b/src/context/RecordingContext.tsx
@@ -9,6 +9,13 @@ import { supabase } from '../services/supabase';
 import { ensureStereo, convertToWav, convertToMp3, downloadBlob } from '../lib/audioExport';
 import { getSignedUrl } from '../lib/storage';
 import { deleteByKey } from '../lib/storage';
+import {
+  getSessionScope,
+  getScopedSavedSessionsKey,
+  mergeSessionsById,
+  migrateLegacySavedSessions,
+  parseStoredArray,
+} from './sessionStorageScope';
 
 interface RecordingEvent {
   timestamp: number;
@@ -99,6 +106,8 @@ const RecordingContextInstance = createContext<RecordingContextValue | null>(nul
 export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user } = useAuth();
   const { trackStudioAction } = useAnalytics();
+  const sessionScope = getSessionScope(user?.id);
+  const scopedSavedSessionsKey = getScopedSavedSessionsKey(sessionScope);
   
   // Performance recording state
   const [isRecordingPerformance, setIsRecordingPerformance] = useState(false);
@@ -118,10 +127,8 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   });
   
   // Sessions state
-  const [savedSessions, setSavedSessions] = useState<RecordingSession[]>(() => {
-    const saved = localStorage.getItem('audafact_savedSessions');
-    return saved ? JSON.parse(saved) : [];
-  });
+  const [savedSessions, setSavedSessions] = useState<RecordingSession[]>([]);
+  const [sessionsHydrated, setSessionsHydrated] = useState(false);
 
   // MediaRecorder ref for audio recording
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -153,9 +160,24 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     refreshSavedRecordings();
   }, [refreshSavedRecordings]);
 
-  // Hydrate savedSessions from DB when user logs in (merge DB + local)
+  // Load scoped local sessions on auth-scope change and migrate legacy key once.
   useEffect(() => {
-    if (!user?.id) return;
+    setSessionsHydrated(false);
+    try {
+      migrateLegacySavedSessions(localStorage, scopedSavedSessionsKey);
+      const loaded = parseStoredArray<RecordingSession>(localStorage.getItem(scopedSavedSessionsKey));
+      setSavedSessions(loaded);
+    } catch (error) {
+      console.error('Failed to load scoped saved sessions:', error);
+      setSavedSessions([]);
+    } finally {
+      setSessionsHydrated(true);
+    }
+  }, [scopedSavedSessionsKey]);
+
+  // Hydrate savedSessions from DB when user logs in (merge DB + current-scope local)
+  useEffect(() => {
+    if (!user?.id || !sessionsHydrated) return;
     let mounted = true;
     (async () => {
       try {
@@ -170,16 +192,14 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
           session_name: s.session_name
         }));
         setSavedSessions(prev => {
-          const dbIds = new Set(dbAsRecording.map(x => x.id));
-          const localOnly = prev.filter(p => !dbIds.has(p.id));
-          return [...dbAsRecording, ...localOnly];
+          return mergeSessionsById(dbAsRecording, prev);
         });
       } catch (err) {
         console.error('Error hydrating sessions from DB:', err);
       }
     })();
     return () => { mounted = false; };
-  }, [user?.id]);
+  }, [user?.id, sessionsHydrated]);
 
   // Refresh saved recordings when a new one is saved
   useEffect(() => {
@@ -198,8 +218,9 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   }, [audioRecordings]);
 
   useEffect(() => {
-    localStorage.setItem('audafact_savedSessions', JSON.stringify(savedSessions));
-  }, [savedSessions]);
+    if (!sessionsHydrated) return;
+    localStorage.setItem(scopedSavedSessionsKey, JSON.stringify(savedSessions));
+  }, [savedSessions, scopedSavedSessionsKey, sessionsHydrated]);
 
   // Combined recording functions
   const startPerformanceRecording = useCallback(async (appAudioContext?: AudioContext) => {
@@ -629,8 +650,8 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     // Also clear from localStorage
     localStorage.removeItem('audafact_performances');
     localStorage.removeItem('audafact_audioRecordings');
-    localStorage.removeItem('audafact_savedSessions');
-  }, []);
+    localStorage.removeItem(scopedSavedSessionsKey);
+  }, [scopedSavedSessionsKey]);
 
   const exportPerformance = useCallback(async (performanceId: string, options?: { filename?: string; format?: 'mp3' | 'wav' }) => {
     const performance = performances.find(p => p.id === performanceId);

--- a/src/context/sessionStorageScope.ts
+++ b/src/context/sessionStorageScope.ts
@@ -1,0 +1,35 @@
+export const SAVED_SESSIONS_KEY = 'audafact_savedSessions';
+export const SAVED_SESSIONS_MIGRATION_FLAG = 'audafact_savedSessions_migrated_v1';
+
+export const getSessionScope = (userId?: string | null): string => userId ? `user:${userId}` : 'guest';
+export const getScopedSavedSessionsKey = (scope: string): string => `${SAVED_SESSIONS_KEY}:${scope}`;
+
+export const parseStoredArray = <T>(raw: string | null): T[] => {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+export const migrateLegacySavedSessions = (storage: Storage, scopedKey: string): void => {
+  const migrationCompleted = storage.getItem(SAVED_SESSIONS_MIGRATION_FLAG) === 'true';
+  const scopedRaw = storage.getItem(scopedKey);
+
+  if (!migrationCompleted) {
+    const legacyRaw = storage.getItem(SAVED_SESSIONS_KEY);
+    if (!scopedRaw && legacyRaw) {
+      storage.setItem(scopedKey, legacyRaw);
+    }
+    storage.removeItem(SAVED_SESSIONS_KEY);
+    storage.setItem(SAVED_SESSIONS_MIGRATION_FLAG, 'true');
+  }
+};
+
+export const mergeSessionsById = <T extends { id: string }>(dbSessions: T[], localSessions: T[]): T[] => {
+  const dbIds = new Set(dbSessions.map((session) => session.id));
+  const localOnly = localSessions.filter((session) => !dbIds.has(session.id));
+  return [...dbSessions, ...localOnly];
+};

--- a/src/hooks/usePostSignupActions.ts
+++ b/src/hooks/usePostSignupActions.ts
@@ -95,13 +95,15 @@ export const usePostSignupActions = () => {
 
   const saveDemoState = useCallback((state: any) => {
     const demoManager = DemoSessionManager.getInstance();
-    demoManager.saveDemoState(state);
-  }, []);
+    const scope = user?.id ? `user:${user.id}` : 'guest';
+    demoManager.saveDemoState(state, scope);
+  }, [user?.id]);
 
   const restoreDemoState = useCallback(() => {
     const demoManager = DemoSessionManager.getInstance();
-    return demoManager.restoreDemoState();
-  }, []);
+    const scope = user?.id ? `user:${user.id}` : 'guest';
+    return demoManager.restoreDemoState(scope);
+  }, [user?.id]);
 
   const clearIntentCache = useCallback(() => {
     const intentService = IntentManagementService.getInstance();

--- a/src/services/demoSessionManager.ts
+++ b/src/services/demoSessionManager.ts
@@ -11,22 +11,26 @@ export class DemoSessionManager {
     }
     return DemoSessionManager.instance;
   }
+
+  private getScopedKey(scope: string = 'guest'): string {
+    return `${DEMO_SESSION_KEY}:${scope}`;
+  }
   
-  saveDemoState(state: DemoSessionState): void {
+  saveDemoState(state: DemoSessionState, scope: string = 'guest'): void {
     try {
       const sessionData = {
         ...state,
         timestamp: Date.now()
       };
-      localStorage.setItem(DEMO_SESSION_KEY, JSON.stringify(sessionData));
+      localStorage.setItem(this.getScopedKey(scope), JSON.stringify(sessionData));
     } catch (error) {
       console.error('Failed to save demo state:', error);
     }
   }
   
-  getDemoState(): DemoSessionState | null {
+  getDemoState(scope: string = 'guest'): DemoSessionState | null {
     try {
-      const stored = localStorage.getItem(DEMO_SESSION_KEY);
+      const stored = localStorage.getItem(this.getScopedKey(scope));
       if (!stored) return null;
       
       const state: DemoSessionState = JSON.parse(stored);
@@ -36,7 +40,7 @@ export class DemoSessionManager {
       const oneHour = 60 * 60 * 1000;
       
       if (now - state.timestamp > oneHour) {
-        this.clearDemoState();
+        this.clearDemoState(scope);
         return null;
       }
       
@@ -47,16 +51,16 @@ export class DemoSessionManager {
     }
   }
   
-  clearDemoState(): void {
+  clearDemoState(scope: string = 'guest'): void {
     try {
-      localStorage.removeItem(DEMO_SESSION_KEY);
+      localStorage.removeItem(this.getScopedKey(scope));
     } catch (error) {
       console.error('Failed to clear demo state:', error);
     }
   }
   
-  restoreDemoState(): boolean {
-    const state = this.getDemoState();
+  restoreDemoState(scope: string = 'guest'): boolean {
+    const state = this.getDemoState(scope);
     if (!state) return false;
     
     try {

--- a/test/context/sessionStorageScope.test.ts
+++ b/test/context/sessionStorageScope.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getSessionScope,
+  getScopedSavedSessionsKey,
+  migrateLegacySavedSessions,
+  parseStoredArray,
+  SAVED_SESSIONS_KEY,
+  SAVED_SESSIONS_MIGRATION_FLAG,
+  mergeSessionsById,
+} from '../../src/context/sessionStorageScope';
+
+describe('sessionStorageScope', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('builds user and guest scopes correctly', () => {
+    expect(getSessionScope('user-a')).toBe('user:user-a');
+    expect(getSessionScope(null)).toBe('guest');
+  });
+
+  it('builds scoped savedSessions key correctly', () => {
+    expect(getScopedSavedSessionsKey('user:user-a')).toBe('audafact_savedSessions:user:user-a');
+  });
+
+  it('parses only array payloads from storage', () => {
+    expect(parseStoredArray(localStorage.getItem('missing'))).toEqual([]);
+    expect(parseStoredArray('{"not":"array"}')).toEqual([]);
+    expect(parseStoredArray('[{"id":"a"}]')).toEqual([{ id: 'a' }]);
+    expect(parseStoredArray('invalid json')).toEqual([]);
+  });
+
+  it('migrates legacy saved sessions once into current scope', () => {
+    const scopedKey = getScopedSavedSessionsKey('user:user-a');
+    localStorage.setItem(SAVED_SESSIONS_KEY, JSON.stringify([{ id: 'legacy' }]));
+
+    migrateLegacySavedSessions(localStorage, scopedKey);
+
+    expect(localStorage.getItem(SAVED_SESSIONS_KEY)).toBeNull();
+    expect(localStorage.getItem(SAVED_SESSIONS_MIGRATION_FLAG)).toBe('true');
+    expect(localStorage.getItem(scopedKey)).toContain('legacy');
+  });
+
+  it('does not overwrite scoped data when migrating', () => {
+    const scopedKey = getScopedSavedSessionsKey('user:user-a');
+    localStorage.setItem(scopedKey, JSON.stringify([{ id: 'scoped' }]));
+    localStorage.setItem(SAVED_SESSIONS_KEY, JSON.stringify([{ id: 'legacy' }]));
+
+    migrateLegacySavedSessions(localStorage, scopedKey);
+
+    expect(localStorage.getItem(scopedKey)).toContain('scoped');
+    expect(localStorage.getItem(scopedKey)).not.toContain('legacy');
+  });
+
+  it('merges db sessions with local-only sessions by id', () => {
+    const dbSessions = [{ id: 'db-1' }, { id: 'db-2' }];
+    const localSessions = [{ id: 'db-2' }, { id: 'local-1' }];
+
+    const merged = mergeSessionsById(dbSessions, localSessions);
+
+    expect(merged).toEqual([{ id: 'db-1' }, { id: 'db-2' }, { id: 'local-1' }]);
+  });
+});

--- a/test/services/DemoSessionManager.test.ts
+++ b/test/services/DemoSessionManager.test.ts
@@ -57,7 +57,7 @@ describe('Demo Session Management', () => {
     };
     
     // Save with old timestamp
-    localStorage.setItem('demo_session_state', JSON.stringify(oldState));
+    localStorage.setItem('demo_session_state:guest', JSON.stringify(oldState));
     
     const restored = demoManager.getDemoState();
     expect(restored).toBeNull();
@@ -108,9 +108,39 @@ describe('Demo Session Management', () => {
     const demoManager = DemoSessionManager.getInstance();
     
     // Store invalid JSON
-    localStorage.setItem('demo_session_state', 'invalid json');
+    localStorage.setItem('demo_session_state:guest', 'invalid json');
     
     const restored = demoManager.getDemoState();
     expect(restored).toBeNull();
+  });
+
+  it('should isolate demo state by scope', () => {
+    const demoManager = DemoSessionManager.getInstance();
+    const guestState: DemoSessionState = {
+      currentTrack: { id: 'guest_track', name: 'Guest Track' },
+      playbackPosition: 5,
+      cuePoints: [],
+      loopRegions: [],
+      mode: 'preview',
+      volume: 1,
+      tempo: 120,
+      timestamp: Date.now()
+    };
+    const userState: DemoSessionState = {
+      currentTrack: { id: 'user_track', name: 'User Track' },
+      playbackPosition: 10,
+      cuePoints: [],
+      loopRegions: [],
+      mode: 'loop',
+      volume: 0.8,
+      tempo: 128,
+      timestamp: Date.now()
+    };
+
+    demoManager.saveDemoState(guestState, 'guest');
+    demoManager.saveDemoState(userState, 'user:user-1');
+
+    expect(demoManager.getDemoState('guest')?.currentTrack?.id).toBe('guest_track');
+    expect(demoManager.getDemoState('user:user-1')?.currentTrack?.id).toBe('user_track');
   });
 }); 


### PR DESCRIPTION
- Use audafact_savedSessions:user:<id> and :guest; migrate legacy key once
- Centralize helpers in sessionStorageScope; merge DB + local by id
- Namespace demo_session_state by scope in DemoSessionManager and hooks
- Add unit tests for migration, parsing, merge, and demo isolation

Made-with: Cursor