### PR TITLE
Add gated Cristian Sigler demo library pack with bulk ingest support.

### DIFF
--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -19,6 +19,7 @@ import { showSignupModal } from '../hooks/useSignupModal';
 import { toPrettySize, normalizeLegacyUrlToKey } from '@/utils/media';
 import { deleteByKey } from '@/lib/storage';
 import { buildApiUrl, API_CONFIG } from '@/config/api';
+import { CRISTIAN_SIGLER_DEMO_SIDE_PANEL_LABEL } from '@/config/demoLibrary';
 import { supabase } from '@/services/supabase';
 import { useSingleAudio } from '@/hooks/useSingleAudio';
 import { ExportRecordingModal } from './ExportRecordingModal';
@@ -29,7 +30,7 @@ interface AudioAsset {
   id: string;
   name: string;
   fileKey: string;
-  type: 'wav' | 'mp3';
+  type: 'wav' | 'mp3' | 'm4a';
   size: string;
   duration?: number;
   fileUrl?: string;
@@ -60,6 +61,8 @@ const IconUser = () => (
     <path d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
   </svg>
 );
+type SidePanelAudioTab = 'my-tracks' | 'library' | 'demo-pack';
+
 const IconBookmark = () => (
   <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
     <path d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
@@ -276,6 +279,8 @@ const SidePanel: React.FC<SidePanelProps> = ({
   const {
     tier,
     libraryTracks: userLibraryTracks,
+    demoCollectionTracks,
+    demoCollectionLoading,
     loading: userLoading,
     libraryCatalogBanner,
   } = useUser();
@@ -313,7 +318,10 @@ const SidePanel: React.FC<SidePanelProps> = ({
   });
   
   // Active submenu items - always start with none selected so Audafact Library content is hidden until user clicks
-  const [activeAudioTab, setActiveAudioTab] = useState<'my-tracks' | 'library' | null>(null);
+  const [activeAudioTab, setActiveAudioTab] = useState<SidePanelAudioTab | null>(
+    null
+  );
+  const demoTabRestoredRef = useRef(false);
   
   const [activeSessionsTab, setActiveSessionsTab] = useState<'saved' | 'shared' | null>(() => {
     const savedTab = localStorage.getItem('sidePanelActiveSessionsTab');
@@ -523,6 +531,34 @@ const SidePanel: React.FC<SidePanelProps> = ({
       }
     }
   }, [pendingSession, savedSessions, user]);
+
+  useEffect(() => {
+    if (demoCollectionTracks.length === 0) {
+      demoTabRestoredRef.current = false;
+    }
+  }, [demoCollectionTracks.length]);
+
+  useEffect(() => {
+    if (
+      demoCollectionTracks.length === 0 ||
+      demoTabRestoredRef.current
+    ) {
+      return;
+    }
+    const saved = localStorage.getItem('sidePanelActiveAudioTab');
+    if (saved === 'demo-pack') {
+      setActiveAudioTab('demo-pack');
+      setAllowEmptyAudioTab(false);
+      demoTabRestoredRef.current = true;
+    }
+  }, [demoCollectionTracks.length]);
+
+  useEffect(() => {
+    if (activeAudioTab === 'demo-pack' && demoCollectionTracks.length === 0) {
+      setActiveAudioTab(null);
+      setAllowEmptyAudioTab(true);
+    }
+  }, [activeAudioTab, demoCollectionTracks.length]);
 
   const suggestedLibraryMatches = useMemo(() => {
     const libraryPool = tier.id === 'guest' ? guestLibraryTracks : userLibraryTracks;
@@ -749,7 +785,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
   };
 
   // Handle submenu item selection
-  const handleAudioTabSelect = (tab: 'my-tracks' | 'library') => {
+  const handleAudioTabSelect = (tab: SidePanelAudioTab) => {
     setActiveAudioTab(prev => {
       const next = prev === tab ? null : tab;
       // If collapsing (setting to null), allow empty so we don't auto-select the other tab
@@ -1143,6 +1179,18 @@ const SidePanel: React.FC<SidePanelProps> = ({
                     ariaControls="my-tracks-content"
                     id="my-tracks-tab"
                   />
+                  {demoCollectionTracks.length > 0 && (
+                    <SidePanelSubMenuItem
+                      label={CRISTIAN_SIGLER_DEMO_SIDE_PANEL_LABEL}
+                      icon={<IconBookmark />}
+                      isActive={activeAudioTab === 'demo-pack'}
+                      onClick={() => handleAudioTabSelect('demo-pack')}
+                      role="tab"
+                      ariaSelected={activeAudioTab === 'demo-pack'}
+                      ariaControls="cristian-sigler-demo-pack-content"
+                      id="cristian-sigler-demo-pack-tab"
+                    />
+                  )}
                 </div>
                 
                 {/* Enhanced Library Content */}
@@ -1291,7 +1339,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
                                                 id: track.id,
                                                 name: track.name,
                                                 fileKey: track.fileKey,
-                                                type: track.type === 'wav' ? 'wav' : 'mp3',
+                                                type: track.type,
                                                 size: track.size,
                                                 bpm: track.bpm,
                                               },
@@ -1333,7 +1381,7 @@ const SidePanel: React.FC<SidePanelProps> = ({
                                                 id: track.id,
                                                 name: track.name,
                                                 fileKey: track.fileKey,
-                                                type: track.type === 'wav' ? 'wav' : 'mp3',
+                                                type: track.type,
                                                 size: track.size,
                                                 bpm: track.bpm,
                                                 key: track.key ?? undefined,
@@ -1446,6 +1494,60 @@ const SidePanel: React.FC<SidePanelProps> = ({
                             ))
                           )}
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {activeAudioTab === 'demo-pack' && demoCollectionTracks.length > 0 && (
+                  <div
+                    id="cristian-sigler-demo-pack-content"
+                    role="tabpanel"
+                    aria-labelledby="cristian-sigler-demo-pack-tab"
+                    className="px-4 py-4 bg-audafact-surface-1 border-t border-audafact-divider"
+                  >
+                    <div className="space-y-4">
+                      <div className="flex items-center justify-between">
+                        <h3 className="text-md font-medium audafact-heading">
+                          {CRISTIAN_SIGLER_DEMO_SIDE_PANEL_LABEL}
+                        </h3>
+                      </div>
+                      <div className="space-y-3">
+                        {demoCollectionLoading ? (
+                          <div className="text-center py-4">
+                            <div className="loading-spinner mx-auto" />
+                            <p className="text-sm audafact-text-secondary mt-2">
+                              Loading tracks...
+                            </p>
+                          </div>
+                        ) : (
+                          demoCollectionTracks.map((track) => (
+                            <LibraryTrackItem
+                              key={track.id}
+                              track={track}
+                              onPreview={() => handlePreviewPlay(track, false)}
+                              isPreviewing={
+                                isPlaying && currentPreviewTrackId === track.id
+                              }
+                              onAddToStudio={() =>
+                                handleAddTrack(
+                                  {
+                                    id: track.id,
+                                    name: track.name,
+                                    fileKey: track.fileKey,
+                                    type: track.type,
+                                    size: track.size,
+                                    bpm: track.bpm,
+                                    key: track.key ?? undefined,
+                                  },
+                                  false
+                                )
+                              }
+                              canAddToStudio={tier.id !== 'guest'}
+                              isProOnly={track.isProOnly || false}
+                            />
+                          ))
+                        )}
                       </div>
                     </div>
                   </div>

--- a/src/config/demoLibrary.ts
+++ b/src/config/demoLibrary.ts
@@ -1,0 +1,16 @@
+/** Supabase app_config.key and library_tracks.demo_collection_slug for the Cristian Sigler demo pack. */
+export const CRISTIAN_SIGLER_DEMO_COLLECTION_KEY =
+  "demo_collection.cristian_sigler_drum_pack_v1";
+
+/** Submenu label in Tracks (exact copy for supplier demo). */
+export const CRISTIAN_SIGLER_DEMO_SIDE_PANEL_LABEL =
+  "Drum Pack on Tape Volume 1 - Cristian Sigler";
+
+export const DEMO_LIBRARY_ACCOUNT_EMAIL = "demo@audafact.com";
+
+export function isDemoLibraryAccount(
+  email: string | null | undefined
+): boolean {
+  if (!email) return false;
+  return email.trim().toLowerCase() === DEMO_LIBRARY_ACCOUNT_EMAIL;
+}

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -18,6 +18,10 @@ import {
   LibraryService,
   DatabaseLibraryTrack,
 } from "../services/libraryService";
+import {
+  CRISTIAN_SIGLER_DEMO_COLLECTION_KEY,
+  isDemoLibraryAccount,
+} from "../config/demoLibrary";
 
 type ResolvedTier = "free" | "starter" | "pro";
 
@@ -25,6 +29,10 @@ export const useUser = () => {
   const { user } = useAuth();
   const [accessTier, setAccessTier] = useState<ResolvedTier | null>(null);
   const [libraryTracks, setLibraryTracks] = useState<LibraryTrack[]>([]);
+  const [demoCollectionTracks, setDemoCollectionTracks] = useState<
+    LibraryTrack[]
+  >([]);
+  const [demoCollectionLoading, setDemoCollectionLoading] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -33,6 +41,8 @@ export const useUser = () => {
       if (!user) {
         setAccessTier(null);
         setLibraryTracks([]);
+        setDemoCollectionTracks([]);
+        setDemoCollectionLoading(false);
         setLoading(false);
         return;
       }
@@ -40,6 +50,7 @@ export const useUser = () => {
       try {
         setLoading(true);
         setError(null);
+        setDemoCollectionTracks([]);
 
         const { data: userData, error: userError } = await supabase
           .from("users")
@@ -77,6 +88,28 @@ export const useUser = () => {
             }
           }
         }
+
+        if (isDemoLibraryAccount(user.email)) {
+          try {
+            setDemoCollectionLoading(true);
+            const { data: demoData, error: demoErr } = await supabase.rpc(
+              "get_demo_collection_tracks",
+              { p_slug: CRISTIAN_SIGLER_DEMO_COLLECTION_KEY }
+            );
+            if (demoErr) {
+              console.error("❌ Error fetching demo collection tracks:", demoErr);
+              setDemoCollectionTracks([]);
+            } else {
+              setDemoCollectionTracks(
+                LibraryService.transformDatabaseTracks(
+                  (demoData ?? []) as DatabaseLibraryTrack[]
+                )
+              );
+            }
+          } finally {
+            setDemoCollectionLoading(false);
+          }
+        }
       } catch (err) {
         console.error("❌ Exception fetching user data:", err);
         setError("Failed to fetch user data");
@@ -87,7 +120,7 @@ export const useUser = () => {
     };
 
     fetchUserData();
-  }, [user?.id]);
+  }, [user?.id, user?.email]);
 
   const tier = useMemo((): UserTier => {
     if (!user) {
@@ -141,7 +174,11 @@ export const useUser = () => {
   return {
     user,
     tier,
+    /** @deprecated use `tier.id`; kept for hooks that still read `userTier` */
+    userTier: tier.id,
     libraryTracks,
+    demoCollectionTracks,
+    demoCollectionLoading,
     libraryCatalogBanner,
     isGuest: tier.id === "guest",
     isFree: tier.id === "free",

--- a/src/services/libraryService.ts
+++ b/src/services/libraryService.ts
@@ -10,27 +10,35 @@ import { supabase } from "./supabase";
 import { LibraryTrack } from "../types/music";
 import { normalizeLegacyUrlToKey } from "@/utils/media";
 
+function normalizeGenreForLibrary(
+  genre: string | string[] | null | undefined
+): string {
+  if (genre == null) return "";
+  if (Array.isArray(genre)) return genre.length ? genre.join(", ") : "";
+  return genre;
+}
+
 /** DB row shape (reflects your table incl. new key columns) */
 export interface DatabaseLibraryTrack {
-  id: string;
+  id?: string;
   track_id: string;
   name: string;
   artist: string | null;
-  genre: string;
+  genre: string | string[];
   bpm: number | null;
   key: string | null;
   beat_times?: number[] | null;
   duration: number | null;
 
-  // legacy URL columns (kept for fallback)
-  file_url: string;
-  preview_url: string | null;
+  // legacy URL columns (kept for fallback; RPC rows may omit)
+  file_url?: string;
+  preview_url?: string | null;
 
   // NEW: object keys in R2 (preferred)
   file_key: string;
   preview_key: string | null;
 
-  type: "wav" | "mp3";
+  type: "wav" | "mp3" | "m4a";
   size: string | null;
 
   // optional metadata
@@ -69,7 +77,7 @@ export class LibraryService {
         id: t.track_id,
         name: t.name,
         artist: t.artist ?? undefined,
-        genre: t.genre,
+        genre: normalizeGenreForLibrary(t.genre),
         bpm: t.bpm ?? 0,
         key: t.key ?? undefined,
         beats:
@@ -96,7 +104,7 @@ export class LibraryService {
     id: string;
     name: string;
     fileKey: string;
-    type: "wav" | "mp3";
+    type: "wav" | "mp3" | "m4a";
     size: string;
     is_demo: boolean;
     bpm?: number;

--- a/src/types/music.ts
+++ b/src/types/music.ts
@@ -202,7 +202,7 @@ export interface LibraryTrack {
   duration: number;
   fileKey: string; // Transformed from database field file_key
   previewKey?: string; // Transformed from database field preview_key
-  type: "wav" | "mp3";
+  type: "wav" | "mp3" | "m4a";
   size: string;
   tags: string[];
   isProOnly?: boolean; // Transformed from database field is_pro_only

--- a/src/views/Studio.tsx
+++ b/src/views/Studio.tsx
@@ -72,7 +72,7 @@ interface AudioAsset {
   id: string;
   name: string;
   fileKey: string;
-  type: 'wav' | 'mp3';
+  type: 'wav' | 'mp3' | 'm4a';
   size: string;
   duration?: number;
   is_demo?: boolean;
@@ -94,7 +94,13 @@ const Studio = () => {
 
   const { modalState, closeSignupModal, showSignupModal: openSignupModal } = useSignupModal();
   const { canPerformAction, getUpgradeMessage } = useAccessControl();
-  const { user, tier, libraryTracks, loading: userLoading } = useUser();
+  const {
+    user,
+    tier,
+    libraryTracks,
+    demoCollectionTracks,
+    loading: userLoading,
+  } = useUser();
   const { trackEvent } = useAnalytics();
   const { accessTier, proAccessSource } = useUserAccess();
   const { isTapTempoActive } = useTapTempo();
@@ -889,26 +895,22 @@ const Studio = () => {
 
 
 
-  // Load library tracks for studio
+  // Load library tracks for studio (main catalog + gated demo collection)
   useEffect(() => {
     if (isGuestMode) {
       // For demo mode, use bundled tracks from DemoProvider
 
       setAvailableAssets([]); // No need to load additional assets in demo mode
-    } else if (user && libraryTracks.length > 0) {
-      // Use library tracks from useUser hook
-      const mapped: AudioAsset[] = LibraryService.transformToAudioAssets(libraryTracks);
-      setAvailableAssets(mapped);
     } else if (user) {
-      // User is logged in but no library tracks yet (still loading)
-
-      setAvailableAssets([]);
+      const main = LibraryService.transformToAudioAssets(libraryTracks);
+      const demo = LibraryService.transformToAudioAssets(demoCollectionTracks);
+      setAvailableAssets([...demo, ...main]);
     } else {
       // Anonymous users (not demo mode, not logged in) - no assets needed
 
       setAvailableAssets([]);
     }
-  }, [libraryTracks, isGuestMode, user]);
+  }, [libraryTracks, demoCollectionTracks, isGuestMode, user]);
 
   // No automatic restoration on load - user must explicitly choose "Start digging" or "Restore previous session"
 
@@ -2564,7 +2566,16 @@ const Studio = () => {
         const file = e.dataTransfer.files[0];
         
         // Validate file type
-        const validAudioTypes = ['audio/wav', 'audio/mp3', 'audio/mpeg', 'audio/aac', 'audio/ogg', 'audio/flac'];
+        const validAudioTypes = [
+          'audio/wav',
+          'audio/mp3',
+          'audio/mpeg',
+          'audio/mp4',
+          'audio/x-m4a',
+          'audio/aac',
+          'audio/ogg',
+          'audio/flac',
+        ];
         const isValidAudioFile = validAudioTypes.includes(file.type) || 
           file.name.toLowerCase().endsWith('.wav') || 
           file.name.toLowerCase().endsWith('.mp3') || 
@@ -2942,8 +2953,15 @@ const Studio = () => {
       }
       const buffer = await context.decodeAudioData(await blob.arrayBuffer());
       
-      // Create a File object from the blob
-      const file = new File([blob], `${asset.name}.${asset.type}`, { type: `audio/${asset.type}` });
+      const mime =
+        asset.type === "m4a"
+          ? "audio/mp4"
+          : asset.type === "mp3"
+            ? "audio/mpeg"
+            : "audio/wav";
+      const file = new File([blob], `${asset.name}.${asset.type}`, {
+        type: mime,
+      });
       
       // Use track tempo from library metadata if valid, otherwise default to 120
       const trackTempo = asset.bpm != null && asset.bpm >= 40 && asset.bpm <= 300 ? asset.bpm : 120;

--- a/supabase/migrations/20260407120000_demo_collection_library_pack.sql
+++ b/supabase/migrations/20260407120000_demo_collection_library_pack.sql
@@ -1,0 +1,368 @@
+-- Demo-only library collections: DB-backed kill switch + segregated tracks excluded from get_user_tracks.
+
+-- 1) App config (no client access; RPCs read via SECURITY DEFINER)
+CREATE TABLE IF NOT EXISTS public.app_config (
+  key TEXT PRIMARY KEY,
+  value JSONB NOT NULL DEFAULT '{}'::jsonb,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE public.app_config IS 'Internal feature toggles; managed via service role / SQL; not exposed to anon/authenticated via RLS.';
+
+ALTER TABLE public.app_config ENABLE ROW LEVEL SECURITY;
+
+-- No policies for anon/authenticated = deny reads/writes for JWT clients
+
+CREATE OR REPLACE FUNCTION public.set_app_config_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_app_config_updated_at ON public.app_config;
+CREATE TRIGGER trg_app_config_updated_at
+  BEFORE INSERT OR UPDATE ON public.app_config
+  FOR EACH ROW EXECUTE FUNCTION public.set_app_config_updated_at();
+
+-- Default off until you enable for the demo session
+INSERT INTO public.app_config (key, value)
+VALUES (
+  'demo_collection.cristian_sigler_drum_pack_v1',
+  '{"enabled": false}'::jsonb
+)
+ON CONFLICT (key) DO NOTHING;
+
+ALTER TABLE public.library_tracks
+  ADD COLUMN IF NOT EXISTS demo_collection_slug TEXT;
+
+COMMENT ON COLUMN public.library_tracks.demo_collection_slug IS
+  'When set, track is excluded from get_user_tracks and only returned via get_demo_collection_tracks for allowlisted users when enabled in app_config.';
+
+CREATE INDEX IF NOT EXISTS idx_library_tracks_demo_collection_slug
+  ON public.library_tracks (demo_collection_slug)
+  WHERE demo_collection_slug IS NOT NULL;
+
+-- 2) Helpers
+CREATE OR REPLACE FUNCTION public.demo_collection_is_enabled(p_slug TEXT)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE(
+    (SELECT (value->>'enabled')::boolean
+     FROM public.app_config
+     WHERE key = p_slug),
+    false
+  );
+$$;
+
+COMMENT ON FUNCTION public.demo_collection_is_enabled(TEXT) IS
+  'Reads app_config for the given collection key; false if missing or enabled not true.';
+
+CREATE OR REPLACE FUNCTION public.demo_collection_user_allowed(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT lower(trim(COALESCE(
+    (SELECT email FROM auth.users WHERE id = p_user_id),
+    ''
+  ))) = 'demo@audafact.com';
+$$;
+
+COMMENT ON FUNCTION public.demo_collection_user_allowed(UUID) IS
+  'True when user email is demo@audafact.com (internal demos).';
+
+-- 3) Replace get_user_tracks — exclude demo collection rows
+CREATE OR REPLACE FUNCTION public.get_user_tracks(user_id UUID)
+RETURNS TABLE (
+  track_id TEXT,
+  name TEXT,
+  artist TEXT,
+  genre TEXT[],
+  bpm INTEGER,
+  key TEXT,
+  duration INTEGER,
+  file_key TEXT,
+  preview_key TEXT,
+  type TEXT,
+  size TEXT,
+  tags TEXT[],
+  is_pro_only BOOLEAN,
+  rotation_week INTEGER,
+  is_active BOOLEAN
+) AS $$
+DECLARE
+  user_tier TEXT;
+  v_cap INTEGER;
+  v_max_pick INTEGER;
+BEGIN
+  SELECT lower(access_tier::text) INTO user_tier
+  FROM public.users
+  WHERE id = user_id;
+
+  IF user_tier IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF user_tier IN ('pro', 'enterprise') THEN
+    RETURN QUERY
+    SELECT
+      lt.track_id,
+      lt.name,
+      lt.artist,
+      lt.genre,
+      lt.bpm,
+      lt.key,
+      lt.duration,
+      lt.file_key,
+      lt.preview_key,
+      lt.type,
+      lt.size,
+      lt.tags,
+      lt.is_pro_only,
+      lt.rotation_week,
+      lt.is_active
+    FROM public.library_tracks lt
+    WHERE lt.is_active = true
+      AND lt.demo_collection_slug IS NULL
+    ORDER BY
+      lt.rotation_week DESC NULLS LAST,
+      lt.family_id,
+      CASE lt.variant_type WHEN 'primary' THEN 0 WHEN 'version' THEN 1 WHEN 'alternate' THEN 2 ELSE 3 END,
+      lt.variant_number,
+      lt.display_rank,
+      lt.name,
+      lt.track_id;
+    RETURN;
+  END IF;
+
+  IF user_tier = 'starter' THEN
+    v_cap := 35;
+    v_max_pick := 2;
+  ELSIF user_tier = 'free' THEN
+    v_cap := 15;
+    v_max_pick := 1;
+  ELSE
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH base AS (
+    SELECT
+      lt.*,
+      CASE lt.variant_type
+        WHEN 'primary' THEN 0
+        WHEN 'version' THEN 1
+        WHEN 'alternate' THEN 2
+        ELSE 3
+      END AS type_ord
+    FROM public.library_tracks lt
+    WHERE lt.is_active = true
+      AND lt.is_pro_only = false
+      AND lt.demo_collection_slug IS NULL
+  ),
+  per_family AS (
+    SELECT
+      b.*,
+      row_number() OVER (
+        PARTITION BY b.family_id
+        ORDER BY
+          b.type_ord,
+          b.variant_number,
+          b.display_rank,
+          b.name,
+          b.track_id
+      ) AS pick_n
+    FROM base b
+  ),
+  family_order AS (
+    SELECT
+      pf.family_id,
+      row_number() OVER (
+        ORDER BY
+          min(pf.display_rank) FILTER (WHERE pf.pick_n = 1),
+          min(pf.name) FILTER (WHERE pf.pick_n = 1),
+          min(pf.track_id) FILTER (WHERE pf.pick_n = 1)
+      ) AS fo
+    FROM per_family pf
+    WHERE pf.pick_n = 1
+    GROUP BY pf.family_id
+  ),
+  candidates AS (
+    SELECT
+      pf.track_id,
+      pf.name,
+      pf.artist,
+      pf.genre,
+      pf.bpm,
+      pf.key,
+      pf.duration,
+      pf.file_key,
+      pf.preview_key,
+      pf.type,
+      pf.size,
+      pf.tags,
+      pf.is_pro_only,
+      pf.rotation_week,
+      pf.is_active,
+      row_number() OVER (
+        ORDER BY
+          pf.pick_n,
+          fo.fo,
+          pf.type_ord,
+          pf.variant_number,
+          pf.name,
+          pf.track_id
+      ) AS sel_rn
+    FROM per_family pf
+    INNER JOIN family_order fo ON fo.family_id = pf.family_id
+    WHERE pf.pick_n <= v_max_pick
+  )
+  SELECT
+    c.track_id,
+    c.name,
+    c.artist,
+    c.genre,
+    c.bpm,
+    c.key,
+    c.duration,
+    c.file_key,
+    c.preview_key,
+    c.type,
+    c.size,
+    c.tags,
+    c.is_pro_only,
+    c.rotation_week,
+    c.is_active
+  FROM candidates c
+  WHERE c.sel_rn <= v_cap
+  ORDER BY c.sel_rn;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.get_user_tracks(UUID) IS
+  'Standard catalog only (demo_collection_slug IS NULL). Pro/enterprise: all active. Free/starter: capped picks per family.';
+
+-- 4) Demo pack RPC: caller must be authenticated demo user; uses auth.uid() only
+CREATE OR REPLACE FUNCTION public.get_demo_collection_tracks(p_slug TEXT)
+RETURNS TABLE (
+  track_id TEXT,
+  name TEXT,
+  artist TEXT,
+  genre TEXT[],
+  bpm INTEGER,
+  key TEXT,
+  duration INTEGER,
+  file_key TEXT,
+  preview_key TEXT,
+  type TEXT,
+  size TEXT,
+  tags TEXT[],
+  is_pro_only BOOLEAN,
+  rotation_week INTEGER,
+  is_active BOOLEAN
+) AS $$
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF NOT public.demo_collection_user_allowed(auth.uid())
+     OR NOT public.demo_collection_is_enabled(p_slug) THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    lt.track_id,
+    lt.name,
+    lt.artist,
+    lt.genre,
+    lt.bpm,
+    lt.key,
+    lt.duration,
+    lt.file_key,
+    lt.preview_key,
+    lt.type,
+    lt.size,
+    lt.tags,
+    lt.is_pro_only,
+    lt.rotation_week,
+    lt.is_active
+  FROM public.library_tracks lt
+  WHERE lt.is_active = true
+    AND lt.demo_collection_slug = p_slug
+  ORDER BY
+    lt.display_rank,
+    lt.name,
+    lt.track_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.get_demo_collection_tracks(TEXT) IS
+  'Returns demo-collection tracks for demo@audafact.com when app_config enables the slug.';
+
+GRANT EXECUTE ON FUNCTION public.get_demo_collection_tracks(TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_demo_collection_tracks(TEXT) TO service_role;
+
+-- 5) Library file access: standard catalog OR enabled demo row for demo user
+CREATE OR REPLACE FUNCTION public.user_has_library_file_access(p_user_id UUID, p_file_key TEXT)
+RETURNS BOOLEAN AS $$
+BEGIN
+  IF auth.uid() IS NULL OR auth.uid() IS DISTINCT FROM p_user_id THEN
+    RETURN false;
+  END IF;
+  IF p_file_key IS NULL OR length(trim(p_file_key)) = 0 THEN
+    RETURN false;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.get_user_tracks(p_user_id) t
+    WHERE t.file_key = p_file_key
+       OR t.preview_key = p_file_key
+  ) THEN
+    RETURN true;
+  END IF;
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.library_tracks lt
+    WHERE lt.is_active = true
+      AND lt.demo_collection_slug IS NOT NULL
+      AND (lt.file_key = p_file_key OR lt.preview_key = p_file_key)
+      AND public.demo_collection_user_allowed(p_user_id)
+      AND public.demo_collection_is_enabled(lt.demo_collection_slug)
+  );
+END;
+$$ LANGUAGE plpgsql STABLE SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.user_has_library_file_access(UUID, TEXT) IS
+  'True if tier allows this library key, or demo user + enabled demo collection row matches key.';
+
+-- 6) RLS: stop leaking demo file keys to other users
+DROP POLICY IF EXISTS "Anyone can view library tracks" ON public.library_tracks;
+
+CREATE POLICY "library_tracks_select_catalog_or_allowed_demo"
+  ON public.library_tracks
+  FOR SELECT
+  TO public
+  USING (
+    demo_collection_slug IS NULL
+    OR (
+      auth.uid() IS NOT NULL
+      AND public.demo_collection_user_allowed(auth.uid())
+      AND public.demo_collection_is_enabled(demo_collection_slug)
+    )
+  );
+
+-- RLS policy expressions invoke these helpers as the querying role
+GRANT EXECUTE ON FUNCTION public.demo_collection_is_enabled(TEXT) TO PUBLIC;
+GRANT EXECUTE ON FUNCTION public.demo_collection_user_allowed(UUID) TO PUBLIC;

--- a/supabase/migrations/20260407140000_library_tracks_allow_m4a.sql
+++ b/supabase/migrations/20260407140000_library_tracks_allow_m4a.sql
@@ -1,0 +1,10 @@
+-- Allow AAC in MP4 container for library ingests (e.g. Cristian Sigler stems).
+ALTER TABLE public.library_tracks
+  DROP CONSTRAINT IF EXISTS library_tracks_type_check;
+
+ALTER TABLE public.library_tracks
+  ADD CONSTRAINT library_tracks_type_check
+  CHECK (type IN ('wav', 'mp3', 'm4a'));
+
+COMMENT ON CONSTRAINT library_tracks_type_check ON public.library_tracks IS
+  'Supported library file kinds; m4a = typically AAC in MP4 (.m4a).';

--- a/tools/ingest-library.mjs
+++ b/tools/ingest-library.mjs
@@ -1,9 +1,32 @@
 // tools/ingest-library.mjs
+//
+// Bulk-upload WAV/MP3 from a folder to R2 and upsert library_tracks in Supabase.
+//
+// Standard catalog (WAV, MP3, M4A):
+//   LIBRARY_INBOX=./my-wavs node tools/ingest-library.mjs
+//
+// Cristian Sigler demo pack (same R2 layout; rows tagged with demo_collection_slug):
+//   LIBRARY_INBOX=./sigler-pack node tools/ingest-library.mjs \
+//     --demo-collection-key=demo_collection.cristian_sigler_drum_pack_v1 \
+//     --artist="Cristian Sigler" \
+//     --track-id-prefix=cs-dptv1
+//
+// Enable the pack in Supabase (no web redeploy) before the demo account can see tracks:
+//   UPDATE public.app_config SET value = '{"enabled": true}'::jsonb
+//   WHERE key = 'demo_collection.cristian_sigler_drum_pack_v1';
+//
+// Disable after the session:
+//   UPDATE public.app_config SET value = '{"enabled": false}'::jsonb
+//   WHERE key = 'demo_collection.cristian_sigler_drum_pack_v1';
+//
 import fs from "node:fs";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { createClient } from "@supabase/supabase-js";
+
+const DEFAULT_DEMO_COLLECTION_KEY =
+  "demo_collection.cristian_sigler_drum_pack_v1";
 
 // --- env ---
 const {
@@ -27,6 +50,31 @@ if (
     "Missing required envs. Create .env.ingest (see instructions)."
   );
   process.exit(1);
+}
+
+function parseArgs(argv) {
+  /** @type {{ demoCollectionKey: string | null; artist: string | null; trackIdPrefix: string; inbox: string }} */
+  const out = {
+    demoCollectionKey: null,
+    artist: null,
+    trackIdPrefix: "cs-dptv1",
+    inbox: LIBRARY_INBOX,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--demo-collection-key=")) {
+      out.demoCollectionKey = a.slice("--demo-collection-key=".length).trim();
+    } else if (a === "--demo-collection-key") {
+      out.demoCollectionKey = DEFAULT_DEMO_COLLECTION_KEY;
+    } else if (a.startsWith("--artist=")) {
+      out.artist = a.slice("--artist=".length).trim() || null;
+    } else if (a.startsWith("--track-id-prefix=")) {
+      out.trackIdPrefix = a.slice("--track-id-prefix=".length).trim() || "cs-dptv1";
+    } else if (a.startsWith("--inbox=")) {
+      out.inbox = a.slice("--inbox=".length).trim() || LIBRARY_INBOX;
+    }
+  }
+  return out;
 }
 
 // --- clients ---
@@ -62,6 +110,18 @@ async function sha256File(filePath) {
   return h.digest("hex");
 }
 
+/**
+ * @param {object} p
+ * @param {string} p.trackId
+ * @param {string} p.name
+ * @param {string} p.fileKey
+ * @param {string} p.contentHash
+ * @param {number} p.sizeBytes
+ * @param {string} p.contentType
+ * @param {'wav'|'mp3'|'m4a'} p.audioType
+ * @param {string | null} p.demoCollectionKey
+ * @param {string | null} p.artist
+ */
 async function upsertTrack({
   trackId,
   name,
@@ -69,21 +129,34 @@ async function upsertTrack({
   contentHash,
   sizeBytes,
   contentType,
+  audioType,
+  demoCollectionKey,
+  artist,
 }) {
-  const { error } = await supa.from("library_tracks").upsert(
-    {
-      track_id: trackId,
-      name,
-      genre: "unsorted",
-      type: "wav",
-      file_key: fileKey,
-      content_hash: contentHash,
-      size_bytes: sizeBytes,
-      content_type: contentType,
-      is_active: true,
-    },
-    { onConflict: "track_id" }
-  );
+  const familyId = kebab(trackId);
+  /** @type {Record<string, unknown>} */
+  const row = {
+    track_id: trackId,
+    name,
+    genre: demoCollectionKey ? ["drums"] : ["unsorted"],
+    type: audioType,
+    file_key: fileKey,
+    content_hash: contentHash,
+    size_bytes: sizeBytes,
+    content_type: contentType,
+    is_active: true,
+    is_pro_only: false,
+    family_id: familyId,
+    variant_type: "primary",
+    variant_number: 0,
+    display_rank: 0,
+    tags: [],
+    demo_collection_slug: demoCollectionKey,
+    artist,
+  };
+  const { error } = await supa.from("library_tracks").upsert(row, {
+    onConflict: "track_id",
+  });
   if (error) throw error;
 }
 
@@ -101,20 +174,45 @@ async function uploadR2(key, filePath, contentType) {
 
 // --- main ---
 async function run() {
-  const dir = path.resolve(LIBRARY_INBOX);
-  const files = fs.readdirSync(dir).filter((f) => /\.(wav|mp3)$/i.test(f));
+  const args = parseArgs(process.argv);
+  const dir = path.resolve(args.inbox);
+  const files = fs.readdirSync(dir).filter((f) => /\.(wav|mp3|m4a)$/i.test(f));
   if (!files.length) {
-    console.log("No WAV/MP3 files found in", dir);
+    console.log("No WAV/MP3/M4A files found in", dir);
     return;
   }
+
+  if (args.demoCollectionKey) {
+    console.log(
+      "Demo collection mode:",
+      args.demoCollectionKey,
+      "artist=",
+      args.artist ?? "(none)",
+      "trackIdPrefix=",
+      args.trackIdPrefix
+    );
+  }
+
   for (const f of files) {
     const full = path.join(dir, f);
     const stat = fs.statSync(full);
     const base = f.replace(/\.[^.]+$/, "");
     const ext = (path.extname(f).slice(1) || "wav").toLowerCase();
+    /** @type {'wav'|'mp3'|'m4a'} */
+    const audioType =
+      ext === "wav" ? "wav" : ext === "m4a" ? "m4a" : "mp3";
+    const uploadContentType =
+      ext === "wav"
+        ? "audio/wav"
+        : ext === "m4a"
+          ? "audio/mp4"
+          : "audio/mpeg";
+    const dbContentType = uploadContentType;
 
-    // You can choose your own track_id. Here we default to a kebab of the base name.
-    const trackId = kebab(base);
+    const slug = kebab(base);
+    const trackId = args.demoCollectionKey
+      ? `${args.trackIdPrefix}-${slug}`
+      : slug;
 
     const digest = await sha256File(full);
     const s = shortHex(digest, 10);
@@ -122,14 +220,17 @@ async function run() {
 
     console.log("→", f, "=>", key);
 
-    await uploadR2(key, full, ext === "wav" ? "audio/wav" : "audio/mpeg");
+    await uploadR2(key, full, uploadContentType);
     await upsertTrack({
       trackId,
       name: base,
       fileKey: key,
       contentHash: digest,
       sizeBytes: stat.size,
-      contentType: ext === "wav" ? "audio/wav" : "audio/mpeg",
+      contentType: dbContentType,
+      audioType,
+      demoCollectionKey: args.demoCollectionKey,
+      artist: args.artist,
     });
   }
   console.log("Done.");


### PR DESCRIPTION
- Supabase: app_config kill switch, demo_collection_slug, get_demo_collection_tracks, tighter library_tracks RLS, user_has_library_file_access for demo keys, m4a type.
- Web: demo@audafact.com fetch + side panel submenu; merge demo assets in Studio; genre array normalization; m4a playback MIME.
- Ingest: demo collection CLI flags and WAV/MP3/M4A uploads.

Made-with: Cursor