### PR TITLE
Fix recording persistence for event-log captures and legacy DB

### DIFF
--- a/src/components/ExportRecordingModal.tsx
+++ b/src/components/ExportRecordingModal.tsx
@@ -17,9 +17,9 @@ interface ExportRecordingModalProps {
   performance: Performance | null;
   isOpen: boolean;
   onClose: () => void;
-  onSave: (filename: string, format: 'mp3' | 'wav') => void;
+  onSave: (filename: string, format: 'mp3' | 'wav') => void | Promise<void>;
   onExport: (filename: string, format: 'mp3' | 'wav') => void;
-  onSaveAndExport: (filename: string, format: 'mp3' | 'wav') => void;
+  onSaveAndExport: (filename: string, format: 'mp3' | 'wav') => void | Promise<void>;
   onCancel?: () => void;
   allowedFormats: ('mp3' | 'wav')[];
   canSave?: boolean;
@@ -88,14 +88,17 @@ export const ExportRecordingModal: React.FC<ExportRecordingModalProps> = ({
     return filename.endsWith(`.${ext}`) ? filename : `${filename}.${ext}`;
   };
 
-  const handleAction = (action: 'save' | 'export' | 'saveAndExport') => {
+  const handleAction = async (action: 'save' | 'export' | 'saveAndExport') => {
     if (!performance) return;
     const finalFilename = getFinalFilename();
-    if (action === 'save') onSave(finalFilename, format);
-    else if (action === 'export') onExport(finalFilename, format);
-    else onSaveAndExport(finalFilename, format);
-    setDropdownOpen(false);
-    onClose();
+    try {
+      if (action === 'save') await Promise.resolve(onSave(finalFilename, format));
+      else if (action === 'export') onExport(finalFilename, format);
+      else await Promise.resolve(onSaveAndExport(finalFilename, format));
+    } finally {
+      setDropdownOpen(false);
+      onClose();
+    }
   };
 
   if (!performance) return null;
@@ -213,7 +216,7 @@ export const ExportRecordingModal: React.FC<ExportRecordingModalProps> = ({
               <div className="flex rounded-lg overflow-hidden border border-audafact-accent-cyan/50">
                 <button
                   type="button"
-                  onClick={() => handleAction('saveAndExport')}
+                  onClick={() => void handleAction('saveAndExport')}
                   className="px-4 py-2 bg-audafact-accent-cyan text-audafact-bg-primary font-medium hover:opacity-90 transition-opacity"
                 >
                   Save & Export
@@ -237,7 +240,7 @@ export const ExportRecordingModal: React.FC<ExportRecordingModalProps> = ({
                 >
                   <button
                     type="button"
-                    onClick={() => handleAction('save')}
+                    onClick={() => void handleAction('save')}
                     disabled={!canSave}
                     className="w-full px-4 py-2 text-left text-sm audafact-text-primary hover:bg-audafact-surface-1 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
@@ -245,14 +248,14 @@ export const ExportRecordingModal: React.FC<ExportRecordingModalProps> = ({
                   </button>
                   <button
                     type="button"
-                    onClick={() => handleAction('export')}
+                    onClick={() => void handleAction('export')}
                     className="w-full px-4 py-2 text-left text-sm audafact-text-primary hover:bg-audafact-surface-1"
                   >
                     Export only
                   </button>
                   <button
                     type="button"
-                    onClick={() => handleAction('saveAndExport')}
+                    onClick={() => void handleAction('saveAndExport')}
                     className="w-full px-4 py-2 text-left text-sm audafact-text-primary hover:bg-audafact-surface-1"
                   >
                     Save & Export

--- a/src/context/RecordingContext.tsx
+++ b/src/context/RecordingContext.tsx
@@ -8,6 +8,7 @@ import {
   NewPerformanceEvent,
   parsePerformanceEvents,
   PerformanceEvent,
+  clonePerformanceEventsForDb,
 } from '../types/performanceEvents';
 import { StorageService } from '../services/storageService';
 import { useAuth } from './AuthContext';
@@ -178,7 +179,12 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     }
   });
   const performanceStartTimeRef = useRef<number>(0);
-  
+  const performancesRef = useRef<Performance[]>([]);
+
+  useEffect(() => {
+    performancesRef.current = performances;
+  }, [performances]);
+
   // Audio recording state
   const [isRecordingAudio, setIsRecordingAudio] = useState(false);
   const [currentAudioRecording, setCurrentAudioRecording] = useState<AudioRecording | null>(null);
@@ -372,6 +378,7 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       const endTime = Date.now();
       const duration = endTime - startTime;
       const eventCount = performanceEventsRef.current.length;
+      const eventsForDb = clonePerformanceEventsForDb(performanceEventsRef.current);
 
       const completedPerformance: Performance = {
         id: performanceId,
@@ -472,7 +479,7 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
                     size_bytes: r2Result.size_bytes,
                     content_type: r2Result.content_type,
                     original_name: r2Result.original_name,
-                    performance_events: performanceEventsRef.current,
+                    performance_events: eventsForDb,
                     event_schema_version: PERFORMANCE_EVENT_SCHEMA_VERSION,
                     performance_meta: { capture_model: captureModel },
                   });
@@ -489,7 +496,7 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
                 recording_url: `local://recording_${Date.now()}.wav`,
                 length: duration / 1000,
                 notes,
-                performance_events: performanceEventsRef.current,
+                performance_events: eventsForDb,
                 event_schema_version: PERFORMANCE_EVENT_SCHEMA_VERSION,
                 performance_meta: { capture_model: captureModel },
               });
@@ -913,15 +920,18 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   }, [user?.id, refreshSavedRecordings, trackStudioAction]);
 
   const savePerformanceName = useCallback(async (performanceId: string, filename: string) => {
-    const performance = performances.find(p => p.id === performanceId);
+    const performance = performancesRef.current.find(p => p.id === performanceId);
     if (!performance || !user?.id) return;
     if (performance.databaseId) {
       await DatabaseService.updateRecordingOriginalName(performance.databaseId, user.id, filename);
       refreshSavedRecordings();
       return;
     }
-    // No databaseId yet: create the save with user's filename (save-only flow)
-    if (!performance.audioBlob) return;
+    // No databaseId yet: create the save with user's filename (save-only flow).
+    // Event-log-only captures have no audioBlob; auto-save still supports them — mirror that here.
+    const eventsForDb = clonePerformanceEventsForDb(performance.events);
+    const eventCount = eventsForDb.length;
+    if (!performance.audioBlob && eventCount === 0) return;
     try {
       const { count: recordingCount } = await supabase
         .from('recordings')
@@ -939,33 +949,49 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       const maxRecordings = getNumericLimitsForDbTier(normalized).maxRecordings;
       if ((recordingCount ?? 0) >= maxRecordings) return;
       const baseName = filename.replace(/\.(mp3|wav)$/i, '') || 'recording';
-      const notes = `Performance recording with ${performance.events?.length ?? 0} events`;
-      const r2Result = await StorageService.uploadRecordingBlob(
-        performance.audioBlob,
-        user.id,
-        undefined,
-        notes,
-        baseName
-      );
+      const notes = `Performance recording with ${eventCount} events`;
       let recordingRecord: Awaited<ReturnType<typeof DatabaseService.createRecording>> = null;
-      if (r2Result) {
-        recordingRecord = await DatabaseService.createRecording({
-          user_id: user.id,
-          session_id: undefined,
-          recording_url: `https://media.audafact.com/${r2Result.key}`,
-          length: performance.duration / 1000,
+      let r2Result: Awaited<ReturnType<typeof StorageService.uploadRecordingBlob>> = null;
+
+      if (performance.audioBlob) {
+        r2Result = await StorageService.uploadRecordingBlob(
+          performance.audioBlob,
+          user.id,
+          undefined,
           notes,
-          file_key: r2Result.key,
-          content_hash: r2Result.content_hash,
-          size_bytes: r2Result.size_bytes,
-          content_type: r2Result.content_type,
-          original_name: filename,
-          performance_events: performance.events,
-          event_schema_version: performance.eventSchemaVersion ?? PERFORMANCE_EVENT_SCHEMA_VERSION,
-          performance_meta: { capture_model: 'audio_plus_events' },
-        });
-      }
-      if (!recordingRecord) {
+          baseName
+        );
+        if (r2Result) {
+          recordingRecord = await DatabaseService.createRecording({
+            user_id: user.id,
+            session_id: undefined,
+            recording_url: `https://media.audafact.com/${r2Result.key}`,
+            length: performance.duration / 1000,
+            notes,
+            file_key: r2Result.key,
+            content_hash: r2Result.content_hash,
+            size_bytes: r2Result.size_bytes,
+            content_type: r2Result.content_type,
+            original_name: filename,
+            performance_events: eventsForDb,
+            event_schema_version: performance.eventSchemaVersion ?? PERFORMANCE_EVENT_SCHEMA_VERSION,
+            performance_meta: { capture_model: 'audio_plus_events' },
+          });
+        }
+        if (!recordingRecord) {
+          recordingRecord = await DatabaseService.createRecording({
+            user_id: user.id,
+            session_id: undefined,
+            recording_url: `local://recording_${Date.now()}.wav`,
+            length: performance.duration / 1000,
+            notes,
+            original_name: filename,
+            performance_events: eventsForDb,
+            event_schema_version: performance.eventSchemaVersion ?? PERFORMANCE_EVENT_SCHEMA_VERSION,
+            performance_meta: { capture_model: 'events_only_fallback' },
+          });
+        }
+      } else {
         recordingRecord = await DatabaseService.createRecording({
           user_id: user.id,
           session_id: undefined,
@@ -973,9 +999,9 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
           length: performance.duration / 1000,
           notes,
           original_name: filename,
-          performance_events: performance.events,
+          performance_events: eventsForDb,
           event_schema_version: performance.eventSchemaVersion ?? PERFORMANCE_EVENT_SCHEMA_VERSION,
-          performance_meta: { capture_model: 'events_only_fallback' },
+          performance_meta: { capture_model: 'events_only' },
         });
       }
       if (recordingRecord) {
@@ -990,7 +1016,7 @@ export const RecordingProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     } catch (error) {
       console.error('Failed to save performance to app:', error);
     }
-  }, [performances, user?.id, refreshSavedRecordings]);
+  }, [user?.id, refreshSavedRecordings]);
 
   const updateRecordingName = useCallback(async (recordingId: string, filename: string) => {
     if (!user?.id) return;

--- a/src/services/databaseService.ts
+++ b/src/services/databaseService.ts
@@ -270,17 +270,74 @@ export class DatabaseService {
   static async createRecording(
     recording: Omit<Recording, "id" | "created_at">
   ): Promise<Recording | null> {
+    const logRecordingError = (err: {
+      message?: string;
+      details?: string;
+      hint?: string;
+      code?: string;
+    }) =>
+      console.error(
+        "Error creating recording:",
+        err?.message ?? err,
+        err?.details,
+        err?.hint,
+        err?.code
+      );
+
+    const isMissingPerformanceEventColumns = (error: {
+      code?: string;
+      message?: string;
+    }) =>
+      error.code === "PGRST204" &&
+      /performance_events|event_schema_version|performance_meta/i.test(
+        error.message ?? ""
+      );
+
     try {
-      const { data, error } = await supabase
+      let { data, error } = await supabase
         .from("recordings")
         .insert(recording)
-        .select()
-        .single();
+        .select();
+
+      if (
+        error &&
+        isMissingPerformanceEventColumns(error) &&
+        (recording.performance_events != null ||
+          recording.event_schema_version != null ||
+          recording.performance_meta != null)
+      ) {
+        console.warn(
+          "[Audafact] recordings table is missing performance event columns. Apply web/supabase/migrations/20260407153000_add_performance_events_to_recordings.sql (e.g. supabase db push). Saving without event_log / performance_meta in DB for now."
+        );
+        const {
+          performance_events: _pe,
+          event_schema_version: _esv,
+          performance_meta: _pm,
+          ...legacyRecording
+        } = recording;
+        ({ data, error } = await supabase
+          .from("recordings")
+          .insert(legacyRecording)
+          .select());
+      }
 
       if (error) throw error;
-      return data;
-    } catch (error) {
-      console.error("Error creating recording:", error);
+      const row = Array.isArray(data) ? data[0] : null;
+      if (!row) {
+        console.error(
+          "Error creating recording: insert returned no rows (check RLS RETURNING / schema)."
+        );
+        return null;
+      }
+      return row as Recording;
+    } catch (error: unknown) {
+      const err = error as {
+        message?: string;
+        details?: string;
+        hint?: string;
+        code?: string;
+      };
+      logRecordingError(err);
       return null;
     }
   }

--- a/src/types/performanceEvents.ts
+++ b/src/types/performanceEvents.ts
@@ -98,3 +98,13 @@ export const parsePerformanceEvents = (value: unknown): PerformanceEvent[] => {
   if (!Array.isArray(value)) return [];
   return value.filter(isPerformanceEvent);
 };
+
+/** JSON-safe deep clone for PostgREST jsonb (strips non-serializable fields). */
+export function clonePerformanceEventsForDb(events: PerformanceEvent[] | undefined): PerformanceEvent[] {
+  if (!events?.length) return [];
+  try {
+    return JSON.parse(JSON.stringify(events)) as PerformanceEvent[];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
- Await Save as / Save & Export before closing export modal to avoid races.
- Resolve in-flight saves against performancesRef; clone events for JSON-safe inserts.
- createRecording: use multi-row select; retry without performance_* columns on PGRST204.
- Add clonePerformanceEventsForDb helper; allow savePerformanceName without audio blob when events exist.

Made-with: Cursor