### PR TITLE
Separate Studio vs Sample Edit playback during region edits.

### DIFF
--- a/src/components/SampleEditMode.tsx
+++ b/src/components/SampleEditMode.tsx
@@ -1,0 +1,156 @@
+import React, { useEffect } from 'react';
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, X } from 'lucide-react';
+
+export interface SampleEditModeProps {
+  /** Stable id for transition key when switching session tracks */
+  sessionTrackId: string;
+  trackLabel: string;
+  children: React.ReactNode;
+  onClose: () => void;
+  onPrevLibrary: () => void;
+  onNextLibrary: () => void;
+  onPrevSessionTrack: () => void;
+  onNextSessionTrack: () => void;
+  hasPrevSessionTrack: boolean;
+  hasNextSessionTrack: boolean;
+  isTrackLoading: boolean;
+}
+
+/**
+ * Full-screen sample edit shell: dimmed backdrop (tap to close), header with library L/R and back,
+ * optional vertical session track arrows, Escape to close. Body is provided by Studio (waveform + controls).
+ */
+const SampleEditMode: React.FC<SampleEditModeProps> = ({
+  sessionTrackId,
+  trackLabel,
+  children,
+  onClose,
+  onPrevLibrary,
+  onNextLibrary,
+  onPrevSessionTrack,
+  onNextSessionTrack,
+  hasPrevSessionTrack,
+  hasNextSessionTrack,
+  isTrackLoading,
+}) => {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[1100] flex items-center justify-center p-3 sm:p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Sample edit"
+    >
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/55 cursor-default"
+        aria-label="Close sample edit"
+        onClick={onClose}
+        data-testid="sample-edit-backdrop"
+      />
+      <div
+        className="relative z-[1] flex max-h-[min(92vh,920px)] w-full max-w-4xl flex-col overflow-hidden rounded-card border border-audafact-divider bg-audafact-surface-1 shadow-card"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex shrink-0 items-center gap-1.5 border-b border-audafact-divider bg-audafact-surface-2 px-2 py-2 sm:gap-2 sm:px-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex shrink-0 items-center gap-1 rounded-lg border border-audafact-divider px-2 py-1.5 text-xs font-medium text-audafact-text-primary hover:bg-audafact-surface-1"
+            title="Back to Studio"
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden />
+            <span className="hidden sm:inline">Back</span>
+          </button>
+
+          <button
+            type="button"
+            disabled={isTrackLoading}
+            onClick={onPrevLibrary}
+            className="inline-flex shrink-0 items-center gap-0.5 rounded-lg border border-audafact-divider px-1.5 py-1.5 text-[11px] font-medium text-audafact-text-secondary hover:bg-audafact-surface-1 hover:text-audafact-accent-cyan disabled:cursor-not-allowed disabled:opacity-50 sm:gap-1 sm:px-2 sm:text-xs"
+            title="Previous library sample"
+          >
+            <ChevronLeft className="h-4 w-4 shrink-0" aria-hidden />
+            <span className="max-w-[4.5rem] truncate sm:max-w-none">Prev sample</span>
+          </button>
+
+          <h2 className="min-w-0 flex-1 truncate text-center text-sm font-semibold audafact-heading sm:text-base">
+            Sample edit — <span className="font-normal text-audafact-text-secondary">{trackLabel}</span>
+          </h2>
+
+          <button
+            type="button"
+            disabled={isTrackLoading}
+            onClick={onNextLibrary}
+            className="inline-flex shrink-0 items-center gap-0.5 rounded-lg border border-audafact-divider px-1.5 py-1.5 text-[11px] font-medium text-audafact-text-secondary hover:bg-audafact-surface-1 hover:text-audafact-accent-cyan disabled:cursor-not-allowed disabled:opacity-50 sm:gap-1 sm:px-2 sm:text-xs"
+            title="Next library sample"
+          >
+            <span className="max-w-[4.5rem] truncate text-right sm:max-w-none">Next sample</span>
+            <ChevronRight className="h-4 w-4 shrink-0" aria-hidden />
+          </button>
+
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex shrink-0 items-center justify-center rounded-lg border border-audafact-divider p-1.5 text-audafact-text-secondary hover:bg-audafact-surface-1 hover:text-audafact-text-primary"
+            title="Close"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
+          <div
+            key={sessionTrackId}
+            className="transition-opacity duration-200 ease-out motion-reduce:transition-none"
+          >
+            {children}
+          </div>
+        </div>
+
+        {(hasPrevSessionTrack || hasNextSessionTrack) && (
+          <footer className="flex shrink-0 items-center justify-center gap-6 border-t border-audafact-divider bg-audafact-surface-2 px-3 py-2">
+            <button
+              type="button"
+              onClick={onPrevSessionTrack}
+              disabled={!hasPrevSessionTrack}
+              className="inline-flex flex-col items-center gap-0.5 rounded-lg px-3 py-1.5 text-xs font-medium text-audafact-text-secondary hover:bg-audafact-surface-1 hover:text-audafact-accent-cyan disabled:cursor-not-allowed disabled:opacity-40"
+              title="Previous track in session"
+            >
+              <ChevronUp className="h-5 w-5" aria-hidden />
+              Previous track
+            </button>
+            <button
+              type="button"
+              onClick={onNextSessionTrack}
+              disabled={!hasNextSessionTrack}
+              className="inline-flex flex-col items-center gap-0.5 rounded-lg px-3 py-1.5 text-xs font-medium text-audafact-text-secondary hover:bg-audafact-surface-1 hover:text-audafact-accent-cyan disabled:cursor-not-allowed disabled:opacity-40"
+              title="Next track in session"
+            >
+              <ChevronDown className="h-5 w-5" aria-hidden />
+              Next track
+            </button>
+          </footer>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SampleEditMode;

--- a/src/components/TrackControls.tsx
+++ b/src/components/TrackControls.tsx
@@ -5,6 +5,7 @@ import { useRecording } from '../context/RecordingContext';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { useUser } from '../hooks/useUser';
 import { PerformanceEvent } from '../types/performanceEvents';
+import { logRegionDragTransport } from '../utils/regionDragTransportDiag';
 
 // Utility function to format cue point timestamps
 const formatCueTimestamp = (seconds: number): string => {
@@ -136,6 +137,13 @@ interface TrackControlsProps {
   seekFunctionRef?: React.MutableRefObject<((seekTime: number) => void) | null>;
   // Toggle playback function ref (for global space bar trigger)
   togglePlaybackFunctionRef?: React.MutableRefObject<(() => void) | null>;
+  /** Imperative stop when loop/cue region drag starts (Waveform first `update`); keeps resume ref in sync. */
+  suspendTransportForRegionDragSyncRef?: React.MutableRefObject<(() => void) | null>;
+  /**
+   * When false (Studio main deck), loop/cue handle drags do not pause Web Audio transport.
+   * Default true for demos or overlays that need drag to suspend deck playback.
+   */
+  pauseTransportOnRegionDrag?: boolean;
   // Recording destination for audio capture
   recordingDestination?: MediaStreamAudioDestinationNode | null;
   // Add drag state props for real-time timestamp updates
@@ -144,6 +152,8 @@ interface TrackControlsProps {
   loopDragState?: { start: number; end: number } | null;
   /** When mode is 'cue', how pads trigger playback. Default 'cue'. */
   chopTriggerStyle?: 'cue' | 'hold' | 'one-shot';
+  /** When set, shows Cue / Hold / One-Shot next to Audio Filters & Cue Points toggles (chop mode). */
+  onChopTriggerStyleChange?: (style: 'cue' | 'hold' | 'one-shot') => void;
 }
 
 const TrackControls = ({ 
@@ -176,9 +186,12 @@ const TrackControls = ({
   trackId,
   seekFunctionRef,
   togglePlaybackFunctionRef,
+  suspendTransportForRegionDragSyncRef,
+  pauseTransportOnRegionDrag = true,
   recordingDestination,
   cueDragState = null,
-  chopTriggerStyle = 'cue'
+  chopTriggerStyle = 'cue',
+  onChopTriggerStyleChange,
 }: TrackControlsProps) => {
   const {
     addRecordingEvent,
@@ -228,6 +241,7 @@ const TrackControls = ({
   const [internalLowpassFreq, setInternalLowpassFreq] = useState(lowpassFreq || 20000);
   const [internalHighpassFreq, setInternalHighpassFreq] = useState(highpassFreq || 20);
   const [isFilterSectionExpanded, setIsFilterSectionExpanded] = useState(false);
+  const [isCueSectionExpanded, setIsCueSectionExpanded] = useState(false);
   const [lowpassInputValue, setLowpassInputValue] = useState(formatFreqDisplay(lowpassFreq || 20000));
   const [highpassInputValue, setHighpassInputValue] = useState(formatFreqDisplay(highpassFreq || 20));
   const [volumeInputValue, setVolumeInputValue] = useState(() => formatVolumeDisplay(volume));
@@ -613,6 +627,34 @@ const TrackControls = ({
     animationFrameRef.current = requestAnimationFrame(updatePlaybackTime);
   }, [isPlaying, audioContext, audioBuffer.duration, onPlaybackTimeChange, mode, loopStart, loopEnd]);
 
+  /** Best-effort audible playhead (for resuming after region-drag pause). */
+  const getLivePlayheadSeconds = useCallback((): number | null => {
+    if (!audioContext || !audioBuffer) return null;
+    if (!audioSourceRef.current) {
+      if (typeof playbackTime === 'number' && Number.isFinite(playbackTime)) return playbackTime;
+      return currentTime;
+    }
+    const ts = audioContext.getOutputTimestamp();
+    const contextTime = ts.contextTime ?? audioContext.currentTime;
+    const elapsed = contextTime - startTimeRef.current;
+    const sourceNode = audioSourceRef.current;
+    const playbackRate = sourceNode.playbackRate.value;
+
+    if (mode === 'loop') {
+      if (!isSourceLoopingRef.current) {
+        const currentPlaybackTime = playbackStartTimeRef.current + elapsed * playbackRate;
+        return Math.min(Math.max(0, currentPlaybackTime), audioBuffer.duration);
+      }
+      const loopDuration = loopEnd - loopStart;
+      if (loopDuration <= 0) return Math.max(0, Math.min(loopStart, audioBuffer.duration));
+      const rawPosition = playbackStartTimeRef.current + elapsed * playbackRate;
+      const offsetInLoop = ((rawPosition - loopStart) % loopDuration + loopDuration) % loopDuration;
+      return Math.min(Math.max(0, loopStart + offsetInLoop), audioBuffer.duration);
+    }
+    const currentPlaybackTime = playbackStartTimeRef.current + elapsed * playbackRate;
+    return Math.min(Math.max(0, currentPlaybackTime), audioBuffer.duration);
+  }, [audioContext, audioBuffer, mode, loopStart, loopEnd, playbackTime, currentTime]);
+
   // Update refs when activeCueIndex changes
   useEffect(() => {
     activeCueIndexRef.current = activeCueIndex;
@@ -880,6 +922,25 @@ const TrackControls = ({
     }
   }, [onPlaybackStateChange]);
 
+  const prevRegionDragRef = useRef(false);
+  const wasPlayingWhenRegionDragRef = useRef(false);
+  /** When pausing for region drag, resume `togglePlayback` from this time (seconds). */
+  const resumePlayheadAfterRegionDragRef = useRef<number | null>(null);
+
+  /** Called from Waveform on first region `update` each gesture (WS7 has no `update-start`). */
+  const suspendTransportForRegionDragSync = useCallback(() => {
+    if (!pauseTransportOnRegionDrag) return;
+    const active = isPlaying || !!audioSourceRef.current;
+    wasPlayingWhenRegionDragRef.current = wasPlayingWhenRegionDragRef.current || active;
+    if (active) {
+      const t = getLivePlayheadSeconds();
+      if (t != null && Number.isFinite(t)) {
+        resumePlayheadAfterRegionDragRef.current = t;
+      }
+      stopChopPlayback();
+    }
+  }, [pauseTransportOnRegionDrag, isPlaying, stopChopPlayback, getLivePlayheadSeconds]);
+
   /** Stop Hold playback for this pad and optionally log `cue_release` (live performance only). */
   const endHoldAtCueIndex = useCallback(
     (cueIndex: number, recordRelease: boolean) => {
@@ -970,13 +1031,16 @@ const TrackControls = ({
   // Handle play/pause functionality
   const togglePlayback = async () => {
     try {
-      const ctx = await ensureAudio();
-      if (!ctx || !audioBuffer) return;
-
-      if (isPlaying) {
-        // Stop playback
+      // Stop path must run synchronously — do not await ensureAudio first or transport keeps
+      // playing (and region-drag / space-to-pause feels delayed or ineffective).
+      const shouldStop = isPlaying || !!audioSourceRef.current;
+      if (shouldStop) {
         if (audioSourceRef.current) {
-          audioSourceRef.current.stop();
+          try {
+            audioSourceRef.current.stop();
+          } catch (_) {
+            /* already stopped */
+          }
           audioSourceRef.current = null;
         }
         if (gainNodeRef.current) {
@@ -999,8 +1063,7 @@ const TrackControls = ({
         if (onPlaybackStateChange) {
           onPlaybackStateChange(false);
         }
-        
-        // Record loop stop event
+
         if (trackId && mode === 'loop') {
           addRecordingEvent({
             type: 'loop_stop',
@@ -1008,85 +1071,131 @@ const TrackControls = ({
             data: { mode }
           });
         }
-      } else {
-        await ensureIosPrimeForStudioPlayback('trackcontrols:toggle-play', ctx);
-        // Start playback - create audio chain manually to ensure current volume and speed are applied
-        const audioChain = createAudioChainWithCurrentSettings(ctx);
-        if (!audioChain) return;
-        
-        const { sourceNode, gainNode, lowpassFilter, highpassFilter } = audioChain;
-        
-        if (mode === 'loop') {
-          // In loop mode, always start from the beginning of the loop region
+        return;
+      }
+
+      const ctx = await ensureAudio();
+      if (!ctx || !audioBuffer) return;
+
+      await ensureIosPrimeForStudioPlayback('trackcontrols:toggle-play', ctx);
+
+      // Start playback - create audio chain manually to ensure current volume and speed are applied
+      const audioChain = createAudioChainWithCurrentSettings(ctx);
+      if (!audioChain) return;
+
+      const resumeSnap = resumePlayheadAfterRegionDragRef.current;
+      resumePlayheadAfterRegionDragRef.current = null;
+
+      const { sourceNode, gainNode, lowpassFilter, highpassFilter } = audioChain;
+
+      if (mode === 'loop') {
+        if (resumeSnap == null) {
           sourceNode.loop = true;
           sourceNode.loopStart = loopStart;
           sourceNode.loopEnd = loopEnd;
           isSourceLoopingRef.current = true;
           sourceNode.start(0, loopStart);
           playbackStartTimeRef.current = loopStart;
-        } else if (mode === 'cue' && activeCueIndex !== null) {
-          const cueStartTime = cuePoints[activeCueIndex];
-          cueStartTimeRef.current = cueStartTime;
-          isSourceLoopingRef.current = false;
-          sourceNode.start(0, cueStartTime);
-          playbackStartTimeRef.current = cueStartTime;
+          setCurrentTime(loopStart);
         } else {
-          isSourceLoopingRef.current = false;
-          sourceNode.start(0, currentTime);
-          playbackStartTimeRef.current = currentTime;
-        }
-
-        audioSourceRef.current = sourceNode;
-        gainNodeRef.current = gainNode;
-        lowpassFilterRef.current = lowpassFilter;
-        highpassFilterRef.current = highpassFilter;
-        setIsPlaying(true);
-        if (onPlaybackStateChange) {
-          onPlaybackStateChange(true);
-        }
-        
-        // Record loop play event
-        if (trackId && mode === 'loop') {
-          addRecordingEvent({
-            type: 'loop_play',
-            trackId,
-            data: { 
-              mode,
-              loopStart,
-              loopEnd,
-              currentTime: playbackStartTimeRef.current
-            }
-          });
-        }
-        startTimeRef.current = ctx.currentTime;
-
-        // Start the animation frame loop for smooth updates
-        lastUpdateTimeRef.current = performance.now();
-        animationFrameRef.current = requestAnimationFrame(updatePlaybackTime);
-
-        sourceNode.onended = () => {
-          if (audioSourceRef.current === sourceNode) {
-            setIsPlaying(false);
-            audioSourceRef.current = null;
-            gainNodeRef.current = null;
-            if (lowpassFilterRef.current) {
-              lowpassFilterRef.current.disconnect();
-              lowpassFilterRef.current = null;
-            }
-            if (highpassFilterRef.current) {
-              highpassFilterRef.current.disconnect();
-              highpassFilterRef.current = null;
-            }
-            if (animationFrameRef.current) {
-              cancelAnimationFrame(animationFrameRef.current);
-              animationFrameRef.current = null;
-            }
-            if (onPlaybackStateChange) {
-              onPlaybackStateChange(false);
-            }
+          const startFrom = Math.min(Math.max(0, resumeSnap), audioBuffer.duration);
+          const within = startFrom >= loopStart && startFrom <= loopEnd;
+          if (within) {
+            sourceNode.loop = true;
+            sourceNode.loopStart = loopStart;
+            sourceNode.loopEnd = loopEnd;
+            isSourceLoopingRef.current = true;
+            sourceNode.start(0, startFrom);
+            playbackStartTimeRef.current = startFrom;
+          } else {
+            sourceNode.loop = false;
+            isSourceLoopingRef.current = false;
+            sourceNode.start(0, startFrom);
+            playbackStartTimeRef.current = startFrom;
           }
-        };
+          setCurrentTime(startFrom);
+          if (onPlaybackTimeChange) {
+            onPlaybackTimeChange(startFrom);
+          }
+        }
+      } else if (mode === 'cue' && activeCueIndex !== null) {
+        const cueDefault = cuePoints[activeCueIndex];
+        const startFrom =
+          resumeSnap != null
+            ? Math.min(Math.max(0, resumeSnap), audioBuffer.duration)
+            : cueDefault;
+        cueStartTimeRef.current = startFrom;
+        isSourceLoopingRef.current = false;
+        sourceNode.start(0, startFrom);
+        playbackStartTimeRef.current = startFrom;
+        setCurrentTime(startFrom);
+        if (onPlaybackTimeChange) {
+          onPlaybackTimeChange(startFrom);
+        }
+      } else {
+        const startFrom =
+          resumeSnap != null
+            ? Math.min(Math.max(0, resumeSnap), audioBuffer.duration)
+            : currentTime;
+        isSourceLoopingRef.current = false;
+        sourceNode.start(0, startFrom);
+        playbackStartTimeRef.current = startFrom;
+        setCurrentTime(startFrom);
+        if (resumeSnap != null && onPlaybackTimeChange) {
+          onPlaybackTimeChange(startFrom);
+        }
       }
+
+      audioSourceRef.current = sourceNode;
+      gainNodeRef.current = gainNode;
+      lowpassFilterRef.current = lowpassFilter;
+      highpassFilterRef.current = highpassFilter;
+      setIsPlaying(true);
+      if (onPlaybackStateChange) {
+        onPlaybackStateChange(true);
+      }
+
+      // Record loop play event
+      if (trackId && mode === 'loop') {
+        addRecordingEvent({
+          type: 'loop_play',
+          trackId,
+          data: {
+            mode,
+            loopStart,
+            loopEnd,
+            currentTime: playbackStartTimeRef.current
+          }
+        });
+      }
+      startTimeRef.current = ctx.currentTime;
+
+      // Start the animation frame loop for smooth updates
+      lastUpdateTimeRef.current = performance.now();
+      animationFrameRef.current = requestAnimationFrame(updatePlaybackTime);
+
+      sourceNode.onended = () => {
+        if (audioSourceRef.current === sourceNode) {
+          setIsPlaying(false);
+          audioSourceRef.current = null;
+          gainNodeRef.current = null;
+          if (lowpassFilterRef.current) {
+            lowpassFilterRef.current.disconnect();
+            lowpassFilterRef.current = null;
+          }
+          if (highpassFilterRef.current) {
+            highpassFilterRef.current.disconnect();
+            highpassFilterRef.current = null;
+          }
+          if (animationFrameRef.current) {
+            cancelAnimationFrame(animationFrameRef.current);
+            animationFrameRef.current = null;
+          }
+          if (onPlaybackStateChange) {
+            onPlaybackStateChange(false);
+          }
+        }
+      };
     } catch (error) {
       console.error('Error in togglePlayback:', error);
       setIsPlaying(false);
@@ -1104,6 +1213,74 @@ const TrackControls = ({
       }
     };
   }, [togglePlaybackFunctionRef, togglePlayback]);
+
+  useEffect(() => {
+    if (!suspendTransportForRegionDragSyncRef) return;
+    if (!pauseTransportOnRegionDrag) {
+      suspendTransportForRegionDragSyncRef.current = null;
+      return () => {
+        suspendTransportForRegionDragSyncRef.current = null;
+      };
+    }
+    suspendTransportForRegionDragSyncRef.current = suspendTransportForRegionDragSync;
+    return () => {
+      suspendTransportForRegionDragSyncRef.current = null;
+    };
+  }, [
+    suspendTransportForRegionDragSyncRef,
+    suspendTransportForRegionDragSync,
+    pauseTransportOnRegionDrag,
+  ]);
+
+  // During cue or loop region drag, stop transport; on release resume if it was playing.
+  // WaveformDisplay also calls suspendTransportForRegionDragSync on the first region `update`
+  // so transport stops as soon as the gesture moves (before this effect runs).
+  useEffect(() => {
+    const cueDragging = cueDragState != null && Object.keys(cueDragState).length > 0;
+    const loopDragging = loopDragState != null;
+    const dragging = cueDragging || loopDragging;
+    const wasDragging = prevRegionDragRef.current;
+
+    if (!pauseTransportOnRegionDrag) {
+      prevRegionDragRef.current = dragging;
+      return;
+    }
+
+    if (dragging && !wasDragging) {
+      const transportWasActive = isPlaying || !!audioSourceRef.current;
+      wasPlayingWhenRegionDragRef.current =
+        wasPlayingWhenRegionDragRef.current || transportWasActive;
+      if (transportWasActive && audioSourceRef.current) {
+        const t = getLivePlayheadSeconds();
+        if (t != null && Number.isFinite(t)) {
+          resumePlayheadAfterRegionDragRef.current = t;
+        }
+      }
+      logRegionDragTransport('TrackControls region-drag effect: drag start → stopChopPlayback', {
+        trackId: trackId ?? '(no trackId)',
+        cueDragging,
+        loopDragging,
+        isPlaying,
+        hadAudioSource: !!audioSourceRef.current,
+        willResumeAfter: wasPlayingWhenRegionDragRef.current,
+      });
+      stopChopPlayback();
+    } else if (!dragging && wasDragging) {
+      if (wasPlayingWhenRegionDragRef.current) {
+        logRegionDragTransport('TrackControls region-drag effect: drag end → resume togglePlayback', {
+          trackId: trackId ?? '(no trackId)',
+        });
+        void togglePlayback();
+      } else {
+        resumePlayheadAfterRegionDragRef.current = null;
+        logRegionDragTransport('TrackControls region-drag effect: drag end (no resume)', {
+          trackId: trackId ?? '(no trackId)',
+        });
+      }
+      wasPlayingWhenRegionDragRef.current = false;
+    }
+    prevRegionDragRef.current = dragging;
+  }, [pauseTransportOnRegionDrag, cueDragState, loopDragState, isPlaying, stopChopPlayback, togglePlayback, getLivePlayheadSeconds]);
 
   type PlayCuePointOptions = {
     chopTriggerStyle?: 'cue' | 'hold' | 'one-shot';
@@ -1580,36 +1757,101 @@ const TrackControls = ({
         </div>
       </div>
 
-      {/* Filter Controls */}
+      {/* Filter Controls + Cue section toggle (chop mode) */}
       <div className="space-y-3">
-        <div className="flex items-center justify-between">
-          <button
-            onClick={() => setIsFilterSectionExpanded(!isFilterSectionExpanded)}
-            className="flex items-center gap-1 px-2 py-1 text-xs font-medium audafact-text-secondary bg-audafact-surface-1 border border-audafact-divider rounded hover:bg-audafact-surface-2 transition-colors duration-200"
-          >
-            <span>Audio Filters {areFiltersActive() && <span className="text-audafact-accent-cyan">●</span>}</span>
-            <svg 
-              className={`w-3 h-3 transition-transform ${isFilterSectionExpanded ? 'rotate-180' : ''}`} 
-              fill="none" 
-              stroke="currentColor" 
-              viewBox="0 0 24 24"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
-          </button>
-          
-          {/* Delete Track Button - positioned opposite to Audio Filters toggle */}
-          {showDeleteButton && onDelete && (
+        <div className="flex w-full min-w-0 flex-wrap items-center gap-y-2 gap-x-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
             <button
-              onClick={onDelete}
-              className="flex items-center gap-1 px-2 py-1 text-xs font-medium audafact-text-secondary hover:text-audafact-red hover:bg-audafact-surface-2 border border-audafact-divider rounded transition-colors duration-200"
-              title="Delete Track"
+              type="button"
+              onClick={() => setIsFilterSectionExpanded(!isFilterSectionExpanded)}
+              className="flex items-center gap-1 px-2 py-1 text-xs font-medium audafact-text-secondary bg-audafact-surface-1 border border-audafact-divider rounded hover:bg-audafact-surface-2 transition-colors duration-200"
+              title={isFilterSectionExpanded ? 'Collapse audio filters' : 'Expand audio filters'}
             >
-              <span>Delete</span>
-              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              <span>Audio Filters {areFiltersActive() && <span className="text-audafact-accent-cyan">●</span>}</span>
+              <svg
+                className={`w-3 h-3 transition-transform ${isFilterSectionExpanded ? 'rotate-180' : ''}`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
               </svg>
             </button>
+            {mode === 'cue' && (
+              <button
+                type="button"
+                onClick={() => setIsCueSectionExpanded(!isCueSectionExpanded)}
+                className="flex items-center gap-1 px-2 py-1 text-xs font-medium audafact-text-secondary bg-audafact-surface-1 border border-audafact-divider rounded hover:bg-audafact-surface-2 transition-colors duration-200"
+                title={isCueSectionExpanded ? 'Collapse cue pads' : 'Expand cue pads'}
+              >
+                <span>Cue Points</span>
+                <svg
+                  className={`w-3 h-3 transition-transform ${isCueSectionExpanded ? 'rotate-180' : ''}`}
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+            )}
+          </div>
+          {((mode === 'cue' && onChopTriggerStyleChange) || (showDeleteButton && onDelete)) && (
+            <div className="flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2">
+              {mode === 'cue' && onChopTriggerStyleChange && (
+                <>
+                  <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide text-audafact-text-secondary sm:text-xs sm:normal-case sm:tracking-normal">
+                    Trigger
+                  </span>
+                  <div className="flex shrink-0 items-center rounded-md border border-audafact-divider bg-audafact-surface-2 p-0.5">
+                    {(['cue', 'hold', 'one-shot'] as const).map((style) => {
+                      const locked = style !== 'cue' && tier.id === 'guest';
+                      return (
+                        <button
+                          key={style}
+                          type="button"
+                          onClick={() => onChopTriggerStyleChange(style)}
+                          title={
+                            locked
+                              ? 'Sign up to unlock Hold and One-Shot modes'
+                              : style === 'cue'
+                                ? 'Jump to cue and continue'
+                                : style === 'hold'
+                                  ? 'Play while held'
+                                  : 'Play slice once'
+                          }
+                          className={`rounded px-1.5 py-1 text-[11px] font-medium transition-colors sm:px-2 sm:py-1 sm:text-xs ${
+                            chopTriggerStyle === style
+                              ? 'bg-audafact-alert-red text-audafact-text-primary shadow-sm'
+                              : locked
+                                ? 'text-audafact-text-secondary opacity-50 hover:opacity-80'
+                                : 'text-audafact-text-secondary hover:text-audafact-text-primary'
+                          }`}
+                        >
+                          {style === 'one-shot' ? 'One-Shot' : style.charAt(0).toUpperCase() + style.slice(1)}
+                          {locked ? ' 🔒' : ''}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </>
+              )}
+              {showDeleteButton && onDelete && (
+                <button
+                  type="button"
+                  onClick={onDelete}
+                  className="flex shrink-0 items-center gap-1 px-2 py-1 text-xs font-medium audafact-text-secondary hover:text-audafact-red hover:bg-audafact-surface-2 border border-audafact-divider rounded transition-colors duration-200"
+                  title="Delete Track"
+                >
+                  <span>Delete</span>
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              )}
+            </div>
           )}
         </div>
 
@@ -1710,12 +1952,10 @@ const TrackControls = ({
             </div>
           </div>
         )}
-      </div>
 
-      {/* Cue Point Controls */}
-      {mode === 'cue' && (
-        <div>
-          <h4 className="text-xs font-medium mb-2 audafact-text-secondary">Cue Points</h4>
+        {/* Cue pads: below filters when both expanded; order unchanged vs previous always-visible block */}
+        {mode === 'cue' && isCueSectionExpanded && (
+          <div>
           {/* First row: 1-5 (indexes 0-4) */}
           <div className="grid grid-cols-5 gap-0.5 md:gap-1 mb-1">
             {cuePoints.slice(0, 5).map((_, index) => {
@@ -1795,7 +2035,8 @@ const TrackControls = ({
             })}
           </div>
         </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/WaveformDisplay.tsx
+++ b/src/components/WaveformDisplay.tsx
@@ -5,6 +5,13 @@ import MeasureDisplay from './MeasureDisplay';
 import GridLines from './GridLines';
 import { TimeSignature } from '../types/music';
 import { showSignupModal } from '../hooks/useSignupModal';
+import {
+  getWaveformScrubDiag,
+  logWaveformScrubDiagBanner,
+  logWaveformScrubHtmlMediaOnceDev,
+  logWaveformScrubPlayAttempt,
+} from '../utils/waveformScrubDiagnostics';
+import { logRegionDragTransport } from '../utils/regionDragTransportDiag';
 
 const PINCH_ZOOM_CONFIG = {
   enabled: true,
@@ -15,6 +22,20 @@ const PINCH_ZOOM_CONFIG = {
   discreteCooldownMs: 120,
 };
 const WAVEFORM_DEBUG_LOGS = false;
+/** Strip under the grid for cue thumb hitboxes (positioned below region); solid bg, not tiled like the wave area. */
+const CUE_THUMB_BOTTOM_PAD_PX = 36;
+
+function primeHtmlMediaForAudibleScrub(wavesurfer: { getMediaElement: () => unknown }) {
+  try {
+    const m = wavesurfer.getMediaElement() as HTMLMediaElement | undefined;
+    if (m && typeof m.muted === 'boolean') {
+      m.muted = false;
+      if (typeof m.volume === 'number' && m.volume === 0) m.volume = 1;
+    }
+  } catch {
+    /* ignore */
+  }
+}
 
 interface WaveformDisplayProps {
   audioFile: File;
@@ -67,6 +88,20 @@ interface WaveformDisplayProps {
   beats?: number[];
   /** Current cue drag time for nearest-beat highlight (null when not dragging) */
   cueDragTime?: number | null;
+  /** WaveSurfer canvas height in CSS pixels (default 120) */
+  waveHeight?: number;
+  /**
+   * When set with `ensureAudioForScrub`, region-drag audition uses short Web Audio grains from this buffer
+   * (same engine as the deck). Without these, drag is silent — HTMLMediaElement scrub was unreliable/silent.
+   */
+  scrubAudioBuffer?: AudioBuffer;
+  /** Must return a running or resumable `AudioContext` (e.g. Studio `ensureAudioBeforeAction`). */
+  ensureAudioForScrub?: () => Promise<AudioContext | null>;
+  /**
+   * Stop deck transport on first WaveSurfer region `update` each drag (WS7 has no `update-start`).
+   * Omit on Studio main deck (performance owns playback). Wire in Sample Edit to TrackControls suspend ref.
+   */
+  suspendTransportOnRegionDragStart?: () => void;
 }
 
 const WaveformDisplay = ({
@@ -111,6 +146,10 @@ const WaveformDisplay = ({
   duration: durationProp,
   beats,
   cueDragTime,
+  waveHeight = 120,
+  scrubAudioBuffer,
+  ensureAudioForScrub,
+  suspendTransportOnRegionDragStart,
 }: WaveformDisplayProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -145,6 +184,15 @@ const WaveformDisplay = ({
   modeRef.current = mode;
   const prevChopTriggerStyleRef = useRef<string | undefined>(chopTriggerStyle);
   const prevPlaybackTimeRef = useRef<number>(playbackTime);
+  /** Latest prop for syncing WaveSurfer after region drag (drag end does not re-run the playback effect). */
+  const playbackTimeRef = useRef(playbackTime);
+  playbackTimeRef.current = playbackTime;
+  /**
+   * When true, canonical playbackTime must not drive WaveSurfer (refs alone don't re-run effects).
+   * Toggled on region drag start/end so the sync effect reliably skips during drag.
+   */
+  /** Grid overlay only: suppress nearest-beat highlight churn during region drag (not used for WaveSurfer sync — that uses regionDragActiveRef). */
+  const [suppressBeatHighlightForRegionDrag, setSuppressBeatHighlightForRegionDrag] = useState(false);
   
   // Ref to track current cuePoints value for use in createRegions callback
   // This avoids stale closure issues when cuePoints values change but length doesn't
@@ -159,13 +207,132 @@ const WaveformDisplay = ({
   const onLoopPointsChangeRef = useRef(onLoopPointsChange);
   const onLoopDragStateChangeRef = useRef(onLoopDragStateChange);
   const onCuePointChangeRef = useRef(onCuePointChange);
-  const lastLoopDragUpdateRef = useRef(0);
-  const lastLoopTrackUpdateRef = useRef(0);
+  const onCueDragStateChangeRef = useRef(onCueDragStateChange);
+  /** True while dragging a loop or cue region — skip syncing canonical playbackTime into WaveSurfer (prevents choppy playhead). */
+  const regionDragActiveRef = useRef(false);
   const lastSentLoopStartRef = useRef<number | undefined>(undefined);
   const lastSentLoopEndRef = useRef<number | undefined>(undefined);
   const onReadyRef = useRef(onReady);
   const onReadyCalledRef = useRef(false);
   const pinchLastStepAtRef = useRef<number>(0);
+
+  const scrubAudioBufferRef = useRef<AudioBuffer | undefined>(undefined);
+  const ensureAudioForScrubRef = useRef<(() => Promise<AudioContext | null>) | undefined>(undefined);
+  const scrubGrainSourceRef = useRef<AudioBufferSourceNode | null>(null);
+  const lastScrubGrainAtRef = useRef(0);
+  const pendingScrubGrainSecRef = useRef<number | null>(null);
+  const scrubGrainScheduleRafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    scrubAudioBufferRef.current = scrubAudioBuffer;
+    ensureAudioForScrubRef.current = ensureAudioForScrub;
+  }, [scrubAudioBuffer, ensureAudioForScrub]);
+
+  const stopRegionScrubGrain = useCallback(() => {
+    const s = scrubGrainSourceRef.current;
+    if (!s) return;
+    try {
+      s.stop();
+    } catch {
+      /* already stopped */
+    }
+    try {
+      s.disconnect();
+    } catch {
+      /* ignore */
+    }
+    scrubGrainSourceRef.current = null;
+  }, []);
+
+  /** Min time between grains; keeps scrub dense enough to hear while limiting work. */
+  const SCRUB_GRAIN_MIN_INTERVAL_MS = 55;
+
+  const cancelPendingScrubGrainSchedule = useCallback(() => {
+    if (scrubGrainScheduleRafRef.current != null) {
+      cancelAnimationFrame(scrubGrainScheduleRafRef.current);
+      scrubGrainScheduleRafRef.current = null;
+    }
+    pendingScrubGrainSecRef.current = null;
+  }, []);
+
+  const playRegionScrubGrain = useCallback(
+    async (headSec: number) => {
+      const buf = scrubAudioBufferRef.current;
+      const ensure = ensureAudioForScrubRef.current;
+      if (!buf || !ensure || buf.duration <= 0) return;
+      const now = performance.now();
+      if (now - lastScrubGrainAtRef.current < SCRUB_GRAIN_MIN_INTERVAL_MS) return;
+      lastScrubGrainAtRef.current = now;
+
+      const ctx = await ensure();
+      if (!ctx) return;
+      try {
+        await ctx.resume();
+      } catch {
+        /* ignore */
+      }
+
+      stopRegionScrubGrain();
+
+      const offset = Math.max(0, Math.min(headSec, buf.duration - 0.001));
+      const grainDur = Math.min(0.045, buf.duration - offset);
+      if (grainDur < 0.008) return;
+
+      const src = ctx.createBufferSource();
+      const gain = ctx.createGain();
+      gain.gain.value = 0.72;
+      src.buffer = buf;
+      src.connect(gain);
+      gain.connect(ctx.destination);
+      src.start(0, offset, grainDur);
+      scrubGrainSourceRef.current = src;
+      src.onended = () => {
+        if (scrubGrainSourceRef.current === src) scrubGrainSourceRef.current = null;
+      };
+
+    },
+    [stopRegionScrubGrain]
+  );
+
+  /** One rAF batch per frame; coalesces many pointer events to a single grain attempt. */
+  const scheduleRegionScrubGrain = useCallback(
+    (headSec: number) => {
+      pendingScrubGrainSecRef.current = headSec;
+      if (scrubGrainScheduleRafRef.current != null) return;
+      scrubGrainScheduleRafRef.current = requestAnimationFrame(() => {
+        scrubGrainScheduleRafRef.current = null;
+        const t = pendingScrubGrainSecRef.current;
+        if (t == null) return;
+        void playRegionScrubGrain(t);
+      });
+    },
+    [playRegionScrubGrain]
+  );
+
+  /** Run after WaveSurfer’s synchronous region work so the handle stays under the cursor. */
+  const queueRegionScrubGrainAfterPointer = useCallback(
+    (headSec: number) => {
+      queueMicrotask(() => scheduleRegionScrubGrain(headSec));
+    },
+    [scheduleRegionScrubGrain]
+  );
+
+  useEffect(() => {
+    return () => {
+      cancelPendingScrubGrainSchedule();
+      stopRegionScrubGrain();
+    };
+  }, [cancelPendingScrubGrainSchedule, stopRegionScrubGrain]);
+
+  const warnedMissingScrubPropsRef = useRef(false);
+  useEffect(() => {
+    if (!import.meta.env.DEV || warnedMissingScrubPropsRef.current) return;
+    if (scrubAudioBuffer && ensureAudioForScrub) return;
+    warnedMissingScrubPropsRef.current = true;
+    console.warn(
+      '[Audafact] Waveform: pass scrubAudioBuffer + ensureAudioForScrub from Studio for audible region scrub. Without them, drag stays silent (HTML scrub disabled during drag).'
+    );
+  }, [scrubAudioBuffer, ensureAudioForScrub]);
 
   const debugLog = useCallback((label: string, details?: unknown) => {
     if (!WAVEFORM_DEBUG_LOGS) return;
@@ -199,6 +366,15 @@ const WaveformDisplay = ({
   useEffect(() => {
     onCuePointChangeRef.current = onCuePointChange;
   }, [onCuePointChange]);
+
+  useEffect(() => {
+    onCueDragStateChangeRef.current = onCueDragStateChange;
+  }, [onCueDragStateChange]);
+
+  const suspendTransportOnRegionDragStartRef = useRef(suspendTransportOnRegionDragStart);
+  useEffect(() => {
+    suspendTransportOnRegionDragStartRef.current = suspendTransportOnRegionDragStart;
+  }, [suspendTransportOnRegionDragStart]);
 
   useEffect(() => {
     zoomLevelRef.current = zoomLevel;
@@ -266,11 +442,15 @@ const WaveformDisplay = ({
     waveColor: '#008CFF',
     progressColor: '#00F5C3',
     cursorColor: '#00F5C3',
-    height: 120,
+    height: waveHeight,
     normalize: true,
     autoplay: false,
     plugins: plugins,
   });
+
+  useEffect(() => {
+    logWaveformScrubDiagBanner(getWaveformScrubDiag());
+  }, []);
 
   // Notify parent when waveform is ready for display (only once per load to prevent infinite loop)
   useEffect(() => {
@@ -342,6 +522,55 @@ const WaveformDisplay = ({
     // Scale from 1x baseline so 2x is exactly 2× the width of 1x (no abrupt jump)
     return basePxPerSec * zoomLevel;
   }, [wavesurfer, isReady, zoomLevel]);
+
+  /** Cue region end time: keep narrow chops (~10ms) at 1x; when zoomed in, slight width cap (~6–10px on screen) so handles stay grabbable without wide slabs. */
+  const getCueRegionEnd = useCallback(
+    (
+      clampedStart: number,
+      index: number,
+      currentCuePoints: number[],
+      duration: number,
+      minPxPerSec: number,
+      zoom: number
+    ) => {
+      const nextT =
+        index < currentCuePoints.length - 1 ? Number(currentCuePoints[index + 1]) : NaN;
+      let span = 0.01;
+      if (zoom > 1) {
+        span = Math.min(0.014, Math.max(0.01, 8 / Math.max(minPxPerSec, 1e-6)));
+      }
+      let end = Math.min(clampedStart + span, duration);
+      if (!Number.isNaN(nextT)) {
+        end = Math.min(end, Math.max(clampedStart + 0.002, nextT - 0.002));
+      }
+      return end;
+    },
+    []
+  );
+
+  /** Re-apply cue region times after zoom/minPxPerSec so RegionsPlugin redraws markers at correct x (same idea as loop refresh). */
+  const syncCueRegionLayoutAfterZoom = useCallback(() => {
+    if (!wavesurfer || !isReady) return;
+    if (modeRef.current !== 'cue') return;
+    const duration = wavesurfer.getDuration();
+    if (duration <= 0) return;
+    const epsilon = 0.05;
+    const minPxPerSec = calculateMinPxPerSec();
+    const pts = currentCuePointsRef.current;
+    const z = zoomLevelRef.current;
+    currentRegionsRef.current.forEach((cueRegion: any, index: number) => {
+      if (!cueRegion?.id?.includes?.('cue-')) return;
+      const point = pts[index];
+      if (typeof point !== 'number' || Number.isNaN(point)) return;
+      const clampedStart = Math.max(0, Math.min(point, duration - epsilon));
+      const regionEnd = getCueRegionEnd(clampedStart, index, pts, duration, minPxPerSec, z);
+      try {
+        cueRegion.setOptions({ start: clampedStart, end: regionEnd });
+      } catch (_) {
+        /* ignore */
+      }
+    });
+  }, [wavesurfer, isReady, calculateMinPxPerSec, getCueRegionEnd]);
 
   // Pixels per second for measure/grid overlays - must match WaveSurfer's actual scale for alignment
   const [pixelsPerSecond, setPixelsPerSecond] = useState(() => 40 * zoomLevel);
@@ -463,6 +692,10 @@ const WaveformDisplay = ({
             const end = Math.max(start + 0.1, Math.min(region.end, duration));
             region.setOptions({ start, end });
           }
+          // Cue/chop regions: same as loop — after zoom, markers must be re-synced or they vanish/misalign.
+          if (widthSyncGeneration === widthSyncGenerationRef.current) {
+            syncCueRegionLayoutAfterZoom();
+          }
         };
         
         renderer.on('rendered', handleRendered);
@@ -508,7 +741,7 @@ const WaveformDisplay = ({
       widthSyncTimeoutsRef.current = [];
       clearInterval(intervalId);
     };
-  }, [wavesurfer, isReady, zoomLevel, mode, calculateMinPxPerSec, debugLog]);
+  }, [wavesurfer, isReady, zoomLevel, mode, calculateMinPxPerSec, debugLog, syncCueRegionLayoutAfterZoom]);
 
   // Auto-scroll to follow playhead during playback with center-lock behavior
   useEffect(() => {
@@ -718,41 +951,75 @@ const WaveformDisplay = ({
 
       // Update parent state only on drop to avoid playback glitching during drag.
       // onLoopDragStateChange provides display-only live values during drag.
-      region.on('update-start', () => {
-        isInternalLoopUpdateRef.current = true;
-        const duration = wavesurfer.getDuration();
-        const epsilon = 0.05;
-        const start = Math.max(0, Math.min(region.start, duration - epsilon));
-        const end = Math.max(start + 0.01, Math.min(region.end, duration));
-        onLoopDragStateChangeRef.current?.(start, end);
-        lastLoopTrackUpdateRef.current = -Infinity;
-      });
+      // WaveSurfer 7 regions emit `update` / `update-end` only — there is no `update-start`.
+      let loopRegionGestureActive = false;
 
       region.on('update', () => {
-        isInternalLoopUpdateRef.current = true;
-        const now = performance.now();
-        const duration = wavesurfer.getDuration();
-        const epsilon = 0.05;
-        const start = Math.max(0, Math.min(region.start, duration - epsilon));
-        const end = Math.max(start + 0.01, Math.min(region.end, duration));
-        if (now - lastLoopDragUpdateRef.current >= 50) {
-          lastLoopDragUpdateRef.current = now;
-          onLoopDragStateChangeRef.current?.(start, end);
-        }
-        if (now - lastLoopTrackUpdateRef.current >= 600) {
-          const prevStart = lastSentLoopStartRef.current;
-          const prevEnd = lastSentLoopEndRef.current;
-          const meaningfulChange = prevStart === undefined || prevEnd === undefined || Math.abs(start - prevStart) > 0.02 || Math.abs(end - prevEnd) > 0.02;
-          if (meaningfulChange) {
-            lastLoopTrackUpdateRef.current = now;
-            lastSentLoopStartRef.current = start;
-            lastSentLoopEndRef.current = end;
-            onLoopPointsChangeRef.current(start, end);
+        if (!loopRegionGestureActive) {
+          loopRegionGestureActive = true;
+          suspendTransportOnRegionDragStartRef.current?.();
+          const scrubDiag = getWaveformScrubDiag();
+          regionDragActiveRef.current = true;
+          setSuppressBeatHighlightForRegionDrag(true);
+          isInternalLoopUpdateRef.current = true;
+          logWaveformScrubHtmlMediaOnceDev(wavesurfer, 'loop-region');
+          const d0 = wavesurfer.getDuration();
+          const eps0 = 0.05;
+          const s0 = Math.max(0, Math.min(region.start, d0 - eps0));
+          const e0 = Math.max(s0 + 0.01, Math.min(region.end, d0));
+          logRegionDragTransport('WaveformDisplay loop-region first update (drag begin)', {
+            trackId: trackId ?? '(no trackId)',
+            scrubNoParent: scrubDiag.noParent,
+            willCallStudioDragHandler: !scrubDiag.noParent,
+            start: s0,
+            end: e0,
+          });
+          if (!scrubDiag.noParent) {
+            onLoopDragStateChangeRef.current?.(s0, e0);
+          }
+          lastScrubGrainAtRef.current = 0;
+          queueRegionScrubGrainAfterPointer(s0);
+          if (scrubDiag.logPlay && !scrubDiag.noAudio) {
+            try {
+              wavesurfer.setPlaybackRate(1);
+            } catch {
+              /* ignore */
+            }
+            primeHtmlMediaForAudibleScrub(wavesurfer);
+            const playPromise = wavesurfer.play(s0);
+            logWaveformScrubPlayAttempt(wavesurfer, 'loop-region', playPromise, true);
+          } else if (scrubDiag.logPlay && scrubDiag.noAudio) {
+            console.info('[WaveformScrubDiag] loop-region first update: noAudio — skipped play()');
           }
         }
+        isInternalLoopUpdateRef.current = true;
+        const dur = wavesurfer.getDuration();
+        const eps = 0.05;
+        const start = Math.max(0, Math.min(region.start, dur - eps));
+        queueRegionScrubGrainAfterPointer(start);
       });
 
       region.on('update-end', () => {
+        loopRegionGestureActive = false;
+        regionDragActiveRef.current = false;
+        cancelPendingScrubGrainSchedule();
+        stopRegionScrubGrain();
+        try {
+          wavesurfer.pause();
+        } catch (_) {
+          /* ignore */
+        }
+        try {
+          wavesurfer.setPlaybackRate(1);
+        } catch {
+          /* ignore */
+        }
+        try {
+          wavesurfer.setTime(playbackTimeRef.current);
+        } catch (_) {
+          /* ignore */
+        }
+        setSuppressBeatHighlightForRegionDrag(false);
         const duration = wavesurfer.getDuration();
         const epsilon = 0.05;
         // Clamp to valid bounds - prevents corrupted values from zoom sync issues
@@ -785,11 +1052,18 @@ const WaveformDisplay = ({
       const epsilon = 0.05; // slightly larger to avoid float issues
       // Use ref to get current cuePoints to avoid stale closure issues
       const currentCuePoints = currentCuePointsRef.current;
+      const minPxPerSec = calculateMinPxPerSec();
       const newRegions = currentCuePoints.map((point, index) => {
         // Clamp start to [0, duration - epsilon]
         const clampedStart = Math.max(0, Math.min(point, duration - epsilon));
-        // Ensure region end does not exceed duration
-        const regionEnd = Math.min(clampedStart + 0.01, duration);
+        const regionEnd = getCueRegionEnd(
+          clampedStart,
+          index,
+          currentCuePoints,
+          duration,
+          minPxPerSec,
+          zoomLevel
+        );
         // One-Shot: grey out thumb node if it is at or past the next node (invalid trigger)
         const currNum = Number(point);
         const nextNum = index < currentCuePoints.length - 1 ? Number(currentCuePoints[index + 1]) : NaN;
@@ -815,32 +1089,76 @@ const WaveformDisplay = ({
           }
         });
 
-        // Add drag event listeners for real-time timestamp updates
-        region.on('update-start', () => {
-          if (onCueDragStateChange) {
-            const cuePoint = region.start + (region.end - region.start) / 2;
-            const clampedCuePoint = Math.max(0, Math.min(wavesurfer.getDuration(), cuePoint));
-            onCueDragStateChange(index, clampedCuePoint);
-          }
-        });
+        let cueRegionGestureActive = false;
 
         region.on('update', () => {
-          if (onCueDragStateChange) {
+          if (!cueRegionGestureActive) {
+            cueRegionGestureActive = true;
+            suspendTransportOnRegionDragStartRef.current?.();
+            const scrubDiag = getWaveformScrubDiag();
+            regionDragActiveRef.current = true;
+            setSuppressBeatHighlightForRegionDrag(true);
+            logWaveformScrubHtmlMediaOnceDev(wavesurfer, `cue-region[${index}]`);
+            const dCue = wavesurfer.getDuration();
             const cuePoint = region.start + (region.end - region.start) / 2;
-            const clampedCuePoint = Math.max(0, Math.min(wavesurfer.getDuration(), cuePoint));
-            onCueDragStateChange(index, clampedCuePoint);
+            const clampedCuePoint = Math.max(0, Math.min(dCue, cuePoint));
+            logRegionDragTransport(`WaveformDisplay cue-region[${index}] first update (drag begin)`, {
+              trackId: trackId ?? '(no trackId)',
+              scrubNoParent: scrubDiag.noParent,
+              willCallStudioDragHandler: !scrubDiag.noParent,
+              clampedCuePoint,
+            });
+            if (!scrubDiag.noParent) {
+              onCueDragStateChangeRef.current?.(index, clampedCuePoint);
+            }
+            lastScrubGrainAtRef.current = 0;
+            queueRegionScrubGrainAfterPointer(clampedCuePoint);
+            if (scrubDiag.logPlay && !scrubDiag.noAudio) {
+              try {
+                wavesurfer.setPlaybackRate(1);
+              } catch {
+                /* ignore */
+              }
+              primeHtmlMediaForAudibleScrub(wavesurfer);
+              const playPromise = wavesurfer.play(clampedCuePoint);
+              logWaveformScrubPlayAttempt(wavesurfer, `cue-region[${index}]`, playPromise, true);
+            } else if (scrubDiag.logPlay && scrubDiag.noAudio) {
+              console.info(`[WaveformScrubDiag] cue-region[${index}] first update: noAudio — skipped play()`);
+            }
           }
+          const mid = region.start + (region.end - region.start) * 0.5;
+          const dur = wavesurfer.getDuration();
+          const head = Math.max(0, Math.min(mid, dur - 0.001));
+          queueRegionScrubGrainAfterPointer(head);
         });
 
         // Only update the cue point and region position, do not recreate all regions
         region.on('update-end', () => {
+          cueRegionGestureActive = false;
+          regionDragActiveRef.current = false;
+          cancelPendingScrubGrainSchedule();
+          stopRegionScrubGrain();
+          try {
+            wavesurfer.pause();
+          } catch (_) {
+            /* ignore */
+          }
+          try {
+            wavesurfer.setPlaybackRate(1);
+          } catch {
+            /* ignore */
+          }
+          try {
+            wavesurfer.setTime(playbackTimeRef.current);
+          } catch (_) {
+            /* ignore */
+          }
+          setSuppressBeatHighlightForRegionDrag(false);
           const cuePoint = region.start + (region.end - region.start) / 2;
           const clampedCuePoint = Math.max(0, Math.min(wavesurfer.getDuration(), cuePoint));
           
           // Clear drag state when drag ends
-          if (onCueDragStateChange) {
-            onCueDragStateChange(index, null);
-          }
+          onCueDragStateChangeRef.current?.(index, null);
           
           // Set flag to indicate this is an internal update from drag
           // This prevents the effect from recreating/updating regions
@@ -900,7 +1218,27 @@ const WaveformDisplay = ({
       currentRegionsRef.current = newRegions;
     }
     debugLog('createRegions done', { token, mode: modeRef.current, count: currentRegionsRef.current.length });
-  }, [wavesurfer, isReady, mode, loopStart, loopEnd, cuePoints.length, trackId, showCueThumbs, isGuestMode, chopTriggerStyle, clearRegions, isRegionOpCurrent, debugLog]);
+  }, [
+    wavesurfer,
+    isReady,
+    mode,
+    loopStart,
+    loopEnd,
+    cuePoints.length,
+    trackId,
+    showCueThumbs,
+    isGuestMode,
+    chopTriggerStyle,
+    clearRegions,
+    isRegionOpCurrent,
+    debugLog,
+    calculateMinPxPerSec,
+    getCueRegionEnd,
+    zoomLevel,
+    queueRegionScrubGrainAfterPointer,
+    cancelPendingScrubGrainSchedule,
+    stopRegionScrubGrain,
+  ]);
 
   // Improved function to add thumb element to a region
   // When isInvalidOneShotTrigger is true (One-Shot mode, node at or past next), style thumb grey
@@ -1068,7 +1406,7 @@ const WaveformDisplay = ({
     } else {
       removeThumbsFromRegions();
     }
-  }, [showCueThumbs, mode, wavesurfer, isReady, chopTriggerStyle, addThumbToRegion, removeThumbsFromRegions]);
+  }, [showCueThumbs, mode, wavesurfer, isReady, chopTriggerStyle, addThumbToRegion, removeThumbsFromRegions, zoomLevel]);
 
   // Handle mode changes explicitly to ensure proper region cleanup
   useEffect(() => {
@@ -1162,7 +1500,15 @@ const WaveformDisplay = ({
           const duration = wavesurfer.getDuration();
           const epsilon = 0.05;
           const clampedStart = Math.max(0, Math.min(cuePoints[changedIndex], duration - epsilon));
-          const regionEnd = Math.min(clampedStart + 0.01, duration);
+          const minPxPerSec = calculateMinPxPerSec();
+          const regionEnd = getCueRegionEnd(
+          clampedStart,
+          changedIndex,
+          cuePoints,
+          duration,
+          minPxPerSec,
+          zoomLevel
+        );
           region.setOptions({
             start: clampedStart,
             end: regionEnd
@@ -1190,7 +1536,23 @@ const WaveformDisplay = ({
     };
     
     handleParameterChange();
-  }, [wavesurfer, isReady, mode, loopStart, loopEnd, cuePoints, chopTriggerStyle, createRegions, clearRegions, beginRegionOp, isRegionOpCurrent, debugLog]);
+  }, [
+    wavesurfer,
+    isReady,
+    mode,
+    loopStart,
+    loopEnd,
+    cuePoints,
+    chopTriggerStyle,
+    createRegions,
+    clearRegions,
+    beginRegionOp,
+    isRegionOpCurrent,
+    debugLog,
+    calculateMinPxPerSec,
+    getCueRegionEnd,
+    zoomLevel,
+  ]);
 
   // Effect to handle initial setup when waveform becomes ready
   useEffect(() => {
@@ -1376,6 +1738,12 @@ const WaveformDisplay = ({
       });
     } else {
       applyZoom(newMinPxPerSec, true);
+      // Backup if renderer 'rendered' doesn't fire — cue chops still need setOptions after zoom()
+      const cueSyncId = setTimeout(() => {
+        syncCueRegionLayoutAfterZoom();
+        zoomChangeRetryTimeoutsRef.current = zoomChangeRetryTimeoutsRef.current.filter((t) => t !== cueSyncId);
+      }, 220);
+      zoomChangeRetryTimeoutsRef.current.push(cueSyncId);
     }
 
     return () => {
@@ -1389,7 +1757,7 @@ const WaveformDisplay = ({
         zoomRenderedHandlerRef.current = null;
       }
     };
-  }, [zoomLevel, wavesurfer, isReady, scrollToCenterPlayhead, calculateMinPxPerSec]);
+  }, [zoomLevel, wavesurfer, isReady, scrollToCenterPlayhead, calculateMinPxPerSec, syncCueRegionLayoutAfterZoom]);
 
   // Effect to handle window resize at 1x zoom
   useEffect(() => {
@@ -1581,6 +1949,8 @@ const WaveformDisplay = ({
   // Optimized playhead update with throttling
   useEffect(() => {
     if (!wavesurfer || !isReady) return;
+    // While dragging loop/cue regions, WaveSurfer time is driven from region handlers + scrub preview.
+    if (regionDragActiveRef.current) return;
 
     const prevDisplayTime = prevPlaybackTimeRef.current;
 
@@ -1640,6 +2010,9 @@ const WaveformDisplay = ({
 
   const horizontalGridSize = calculateHorizontalGridSize();
 
+  // Cue thumbs sit below the region (hitbox bottom: -4px, 40px tall) — reserve strip so overflow:hidden doesn't clip.
+  const cueThumbBottomPadPx = mode === 'cue' && showCueThumbs ? CUE_THUMB_BOTTOM_PAD_PX : 0;
+
   return (
     <div className="w-full box-border overflow-hidden relative">
       {/* Compact Zoom Controls Overlay */}
@@ -1688,7 +2061,10 @@ const WaveformDisplay = ({
           ref={scrollContainerRef}
           style={{ 
             overflowX: zoomLevel <= 1 ? 'hidden' : 'auto', 
-            overflowY: 'hidden'
+            overflowY: 'hidden',
+            paddingBottom: cueThumbBottomPadPx,
+            // Solid band under the grid for thumbs (no extra horizontal grid rows)
+            backgroundColor: cueThumbBottomPadPx ? '#111827' : undefined,
           }}
         >
           <div
@@ -1696,7 +2072,7 @@ const WaveformDisplay = ({
             ref={containerRef}
             className={`box-border ${zoomLevel <= 1 ? 'w-full' : ''}`}
             style={{ 
-              height: '170px', 
+              height: `${waveHeight}px`,
               minWidth: zoomLevel <= 1 ? '100%' : undefined,
               position: 'relative',
               backgroundColor: '#111827',
@@ -1722,7 +2098,7 @@ const WaveformDisplay = ({
                 visible={true}
                 showMeasures={internalShowMeasures}
                 beats={beats}
-                highlightTime={cueDragTime}
+                highlightTime={suppressBeatHighlightForRegionDrag ? null : cueDragTime}
               />
             )}
             
@@ -1749,11 +2125,21 @@ const WaveformDisplay = ({
 };
 
 const WaveformDisplayContainer = (props: WaveformDisplayProps) => {
+  const h = props.waveHeight ?? 120;
+  const cuePad =
+    props.mode === 'cue' && (props.showCueThumbs ?? true)
+      ? CUE_THUMB_BOTTOM_PAD_PX
+      : 0;
+  // Match scroll column only: grid (h) + optional solid strip for cue thumbs. Zoom overlays the top — no extra +34 slack.
+  const outerH = h + cuePad;
   return (
-     <div className="w-full relative box-border overflow-hidden audafact-waveform-bg" style={{ height: '190px' }}>
-       <WaveformDisplay {...props} />
-     </div>
+    <div
+      className="audafact-waveform-bg relative box-border w-full overflow-hidden"
+      style={{ height: `${outerH}px` }}
+    >
+      <WaveformDisplay {...props} />
+    </div>
   );
-}
+};
 
 export default WaveformDisplayContainer;

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -22,6 +22,7 @@ import {
   CRISTIAN_SIGLER_DEMO_COLLECTION_KEY,
   isDemoLibraryAccount,
 } from "../config/demoLibrary";
+import { fetchUserProfileRow } from "../services/userProfileFetch";
 
 type ResolvedTier = "free" | "starter" | "pro";
 
@@ -52,11 +53,7 @@ export const useUser = () => {
         setError(null);
         setDemoCollectionTracks([]);
 
-        const { data: userData, error: userError } = await supabase
-          .from("users")
-          .select("access_tier")
-          .eq("id", user.id)
-          .single();
+        const { data: userData, error: userError } = await fetchUserProfileRow(user.id);
 
         if (userError) {
           console.error("❌ Error fetching user tier:", userError);

--- a/src/hooks/useUserAccess.ts
+++ b/src/hooks/useUserAccess.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
-import { supabase } from '../services/supabase';
+import { fetchUserProfileRow } from '../services/userProfileFetch';
 
 interface UserAccess {
   accessTier: 'free' | 'starter' | 'pro' | null;
@@ -38,11 +38,7 @@ export const useUserAccess = (): UserAccess => {
         setLoading(true);
         setError(null);
 
-        const { data, error: fetchError } = await supabase
-          .from('users')
-          .select('access_tier, subscription_id, plan_interval, pro_access_source, pro_expires_at')
-          .eq('id', user.id)
-          .single();
+        const { data, error: fetchError } = await fetchUserProfileRow(user.id);
 
         if (fetchError) {
           setError(fetchError.message);
@@ -53,8 +49,8 @@ export const useUserAccess = (): UserAccess => {
           else if (t === 'starter') setAccessTier('starter');
           else setAccessTier('free');
           setSubscriptionId(data?.subscription_id || null);
-          setPlanInterval(data?.plan_interval || null);
-          setProAccessSource(data?.pro_access_source || null);
+          setPlanInterval((data?.plan_interval as 'monthly' | 'yearly') || null);
+          setProAccessSource((data?.pro_access_source as 'founder_manual' | 'invite_code') || null);
           setProExpiresAt(data?.pro_expires_at || null);
         }
       } catch (err) {

--- a/src/services/userProfileFetch.ts
+++ b/src/services/userProfileFetch.ts
@@ -1,0 +1,41 @@
+import { supabase } from './supabase';
+
+export type UserProfileRow = {
+  access_tier: string | null;
+  subscription_id: string | null;
+  plan_interval: string | null;
+  pro_access_source: string | null;
+  pro_expires_at: string | null;
+};
+
+type ProfileResult = {
+  data: UserProfileRow | null;
+  error: { message: string } | null;
+};
+
+/** In-flight dedupe: concurrent callers (e.g. useUser + useUserAccess on Studio) share one request. */
+const inflight = new Map<string, Promise<ProfileResult>>();
+
+/**
+ * Single row read for Studio hooks. Replaces duplicate `select(access_tier)` + wider selects.
+ */
+export function fetchUserProfileRow(userId: string): Promise<ProfileResult> {
+  const existing = inflight.get(userId);
+  if (existing) return existing;
+
+  const p = supabase
+    .from('users')
+    .select('access_tier, subscription_id, plan_interval, pro_access_source, pro_expires_at')
+    .eq('id', userId)
+    .single()
+    .then(({ data, error }) => ({
+      data: data as UserProfileRow | null,
+      error: error ? { message: error.message } : null,
+    }))
+    .finally(() => {
+      inflight.delete(userId);
+    });
+
+  inflight.set(userId, p);
+  return p;
+}

--- a/src/utils/regionDragTransportDiag.ts
+++ b/src/utils/regionDragTransportDiag.ts
@@ -1,0 +1,30 @@
+/**
+ * Opt-in diagnostics for region-drag → Studio state → TrackControls transport pause.
+ *
+ * Append to the URL: ?regionDragTransportDiag=1
+ *
+ * Logs (console):
+ * - WaveformDisplay: first region `update` (drag begin), whether scrub diag skipped parent (noParent)
+ * - Studio: handleLoopDragStateChange / handleCueDragStateChange invocations
+ * - TrackControls: region-drag effect → stop transport vs resume vs noop
+ */
+
+export function isRegionDragTransportDiagEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return new URLSearchParams(window.location.search).get('regionDragTransportDiag') === '1';
+  } catch {
+    return false;
+  }
+}
+
+const PREFIX = '[RegionDragTransportDiag]';
+
+export function logRegionDragTransport(message: string, data?: Record<string, unknown>): void {
+  if (!isRegionDragTransportDiagEnabled()) return;
+  if (data && Object.keys(data).length > 0) {
+    console.info(PREFIX, message, data);
+  } else {
+    console.info(PREFIX, message);
+  }
+}

--- a/src/utils/waveformScrubDiagnostics.ts
+++ b/src/utils/waveformScrubDiagnostics.ts
@@ -1,0 +1,152 @@
+/**
+ * Runtime diagnostics for WaveSurfer region scrub (loop/cue drag). Enable without rebuilding
+ * by appending a query string, or set VITE_WAVEFORM_SCRUB_DIAG in .env for dev.
+ *
+ * Query: ?waveformScrubDiag=log,noAudio,noParent
+ *   - 1, true, yes  — shorthand for log only (not "all")
+ *   - log           — on drag start, try play() and log result + HTMLMediaElement snapshot
+ *   - noAudio       — skip play() during diag (isolates UI vs HTML audio)
+ *   - noParent      — skip Studio drag callbacks during drag (isolates React churn vs WaveSurfer)
+ *   - all           — same as log,noAudio,noParent
+ *
+ * Dev: first region drag logs HTML media element once (no query needed).
+ *
+ * Examples:
+ *   ?waveformScrubDiag=1
+ *   ?waveformScrubDiag=log
+ *   ?waveformScrubDiag=noAudio
+ *   ?waveformScrubDiag=noParent
+ */
+
+export type WaveformScrubDiag = {
+  enabled: boolean;
+  /** Log play() promise + media element state */
+  logPlay: boolean;
+  /** Do not call play() or scheduleRegionScrub during drag */
+  noAudio: boolean;
+  /** Do not call onLoopDragStateChange / onCueDragStateChange during drag */
+  noParent: boolean;
+};
+
+const PREFIX = '[WaveformScrubDiag]';
+
+function parseDiagRaw(raw: string): WaveformScrubDiag {
+  const s = raw.trim();
+  if (!s) {
+    return { enabled: false, logPlay: false, noAudio: false, noParent: false };
+  }
+  const lower = s.toLowerCase();
+  // Single token: log-only (does not enable noAudio/noParent — those were easy to trigger by mistake)
+  if (lower === '1' || lower === 'true' || lower === 'yes') {
+    return { enabled: true, logPlay: true, noAudio: false, noParent: false };
+  }
+  const parts = s.split(',').map((p) => p.trim().toLowerCase()).filter(Boolean);
+  const all = parts.includes('all');
+  return {
+    enabled: true,
+    logPlay: all || parts.includes('log'),
+    noAudio: all || parts.includes('noaudio'),
+    noParent: all || parts.includes('noparent') || parts.includes('no_parent'),
+  };
+}
+
+/**
+ * Read flags from ?waveformScrubDiag=... (wins) or import.meta.env.VITE_WAVEFORM_SCRUB_DIAG.
+ * Safe on SSR (returns all false).
+ */
+export function getWaveformScrubDiag(): WaveformScrubDiag {
+  if (typeof window === 'undefined') {
+    return { enabled: false, logPlay: false, noAudio: false, noParent: false };
+  }
+  try {
+    const q = new URLSearchParams(window.location.search).get('waveformScrubDiag');
+    const env =
+      typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_WAVEFORM_SCRUB_DIAG
+        ? String(import.meta.env.VITE_WAVEFORM_SCRUB_DIAG)
+        : '';
+    const raw = (q ?? env).trim();
+    return parseDiagRaw(raw);
+  } catch {
+    return { enabled: false, logPlay: false, noAudio: false, noParent: false };
+  }
+}
+
+type MediaLike = {
+  getMediaElement: () => unknown;
+};
+
+function snapshotHtmlMedia(el: unknown, context: string): void {
+  if (!el || typeof el !== 'object') {
+    console.info(PREFIX, context, 'getMediaElement():', el);
+    return;
+  }
+  const m = el as HTMLMediaElement;
+  const snap = {
+    tag: (el as { nodeName?: string }).nodeName,
+    paused: m.paused,
+    muted: m.muted,
+    volume: m.volume,
+    readyState: m.readyState,
+    error: m.error ? { code: m.error.code, message: m.error.message } : null,
+    currentTime: typeof m.currentTime === 'number' ? m.currentTime.toFixed(4) : m.currentTime,
+    duration: typeof m.duration === 'number' && !Number.isNaN(m.duration) ? m.duration.toFixed(4) : m.duration,
+    playbackRate: m.playbackRate,
+  };
+  console.info(PREFIX, context, snap);
+}
+
+/**
+ * Attach logging to wavesurfer.play() result. Call with the promise returned by play().
+ */
+export function logWaveformScrubPlayAttempt(
+  wavesurfer: MediaLike,
+  context: string,
+  playPromise: Promise<void>,
+  logPlay: boolean
+): void {
+  if (!logPlay) return;
+  playPromise
+    .then(() => {
+      requestAnimationFrame(() => {
+        snapshotHtmlMedia(wavesurfer.getMediaElement(), `${context}: after play() resolve`);
+      });
+    })
+    .catch((err: unknown) => {
+      console.warn(PREFIX, `${context}: play() rejected`, err);
+      requestAnimationFrame(() => {
+        snapshotHtmlMedia(wavesurfer.getMediaElement(), `${context}: after play() reject`);
+      });
+    });
+}
+
+/** One-shot log when diagnostics are active (e.g. on WaveformDisplay mount). */
+export function logWaveformScrubDiagBanner(d: WaveformScrubDiag): void {
+  if (!d.enabled) return;
+  console.info(
+    PREFIX,
+    'enabled —',
+    [
+      d.logPlay && 'log',
+      d.noAudio && 'noAudio',
+      d.noParent && 'noParent',
+    ]
+      .filter(Boolean)
+      .join(', ') || '(flags parsed but none set; use log, noAudio, noParent, or all)'
+  );
+}
+
+let devHtmlMediaLoggedOnce = false;
+
+/** Dev-only: log HTML media element once per page (no query flag). Helps debug silent scrub. */
+export function logWaveformScrubHtmlMediaOnceDev(wavesurfer: MediaLike, context: string): void {
+  try {
+    if (typeof import.meta !== 'undefined' && import.meta.env && !import.meta.env.DEV) return;
+  } catch {
+    return;
+  }
+  if (devHtmlMediaLoggedOnce) return;
+  devHtmlMediaLoggedOnce = true;
+  queueMicrotask(() => {
+    snapshotHtmlMedia(wavesurfer.getMediaElement(), `${context} (dev once)`);
+  });
+}

--- a/src/views/Studio.tsx
+++ b/src/views/Studio.tsx
@@ -27,6 +27,8 @@ import HelpButton from '../components/HelpButton';
 import HelpModal from '../components/HelpModal';
 import { loadPreferredMode, savePreferredMode } from '../components/GetStartedFlowModal';
 import Tooltip from '../components/Tooltip';
+import SampleEditMode from '../components/SampleEditMode';
+import { logRegionDragTransport } from '../utils/regionDragTransportDiag';
 // import { AccessService } from '../services/accessService';
 import { TimeSignature, UserTrack } from '../types/music';
 import { useUser } from '../hooks/useUser';
@@ -157,6 +159,10 @@ const Studio = () => {
   // Track drag state for real-time timestamp updates
   const [cueDragStates, setCueDragStates] = useState<{ [trackId: string]: { [index: number]: number } }>({});
   const [loopDragStates, setLoopDragStates] = useState<{ [trackId: string]: { start: number; end: number } }>({});
+  /** When set, Sample Edit overlay is open for this track id (signed-in only; cue/loop). */
+  const [sampleEditTrackId, setSampleEditTrackId] = useState<string | null>(null);
+  const sampleEditPlaybackSnapshotRef = useRef<Set<string> | null>(null);
+  const lastTapForSampleEditRef = useRef<{ t: number; x: number; y: number; trackId: string } | null>(null);
   // Unified list of assets available for navigation (Supabase library only)
   const [availableAssets, setAvailableAssets] = useState<AudioAsset[]>([]);
   
@@ -418,7 +424,10 @@ const Studio = () => {
   const [showCueThumbs, setShowCueThumbs] = useState<{ [key: string]: boolean }>({});
   // Add playback state tracking
   const [playbackStates, setPlaybackStates] = useState<{ [key: string]: boolean }>({});
-  
+  const playbackStatesRef = useRef<{ [key: string]: boolean }>({});
+  useEffect(() => {
+    playbackStatesRef.current = playbackStates;
+  }, [playbackStates]);
 
   
   // Add accordion state for collapsible controls
@@ -429,7 +438,11 @@ const Studio = () => {
   
   // Store toggle playback functions for each track (for global space bar)
   const togglePlaybackRefs = useRef<{ [key: string]: React.MutableRefObject<(() => void) | null> }>({});
-  
+  /** Sample Edit overlay only: sync Waveform region-drag with TrackControls pause/resume. */
+  const suspendTransportForRegionDragSyncRefs = useRef<{
+    [key: string]: React.MutableRefObject<(() => void) | null>;
+  }>({});
+
   // Get or create seek function ref for a track
   const getSeekFunctionRef = useCallback((trackId: string) => {
     if (!seekFunctionRefs.current[trackId]) {
@@ -444,6 +457,13 @@ const Studio = () => {
       togglePlaybackRefs.current[trackId] = { current: null };
     }
     return togglePlaybackRefs.current[trackId];
+  }, []);
+
+  const getSuspendTransportForRegionDragSyncRef = useCallback((trackId: string) => {
+    if (!suspendTransportForRegionDragSyncRefs.current[trackId]) {
+      suspendTransportForRegionDragSyncRefs.current[trackId] = { current: null };
+    }
+    return suspendTransportForRegionDragSyncRefs.current[trackId];
   }, []);
 
   // Global play: play/pause all armed loop tracks (same as space bar)
@@ -466,6 +486,45 @@ const Studio = () => {
       }
     });
   }, [tracks, playbackStates, getTogglePlaybackRef]);
+
+  const closeSampleEditMode = useCallback(() => {
+    const snap = sampleEditPlaybackSnapshotRef.current;
+    sampleEditPlaybackSnapshotRef.current = null;
+    setSampleEditTrackId(null);
+    if (snap && snap.size > 0) {
+      requestAnimationFrame(() => {
+        snap.forEach((id) => {
+          if (!playbackStatesRef.current[id]) {
+            getTogglePlaybackRef(id).current?.();
+          }
+        });
+      });
+    }
+  }, [getTogglePlaybackRef]);
+
+  const openSampleEditMode = useCallback(
+    (trackId: string) => {
+      if (isGuestMode) return;
+      const t = tracks.find((tr) => tr.id === trackId);
+      if (!t) return;
+      const playing = new Set<string>();
+      tracks.forEach((tr) => {
+        if (playbackStates[tr.id]) playing.add(tr.id);
+      });
+      sampleEditPlaybackSnapshotRef.current = playing;
+      stopAllPlayback();
+      setSelectedCueTrackId(trackId);
+      setSampleEditTrackId(trackId);
+    },
+    [isGuestMode, tracks, playbackStates, stopAllPlayback]
+  );
+
+  useEffect(() => {
+    if (sampleEditTrackId && !tracks.some((t) => t.id === sampleEditTrackId)) {
+      sampleEditPlaybackSnapshotRef.current = null;
+      setSampleEditTrackId(null);
+    }
+  }, [tracks, sampleEditTrackId]);
 
   useEffect(() => {
     const handleRecordingCompleted = () => stopAllPlayback();
@@ -1292,13 +1351,19 @@ const Studio = () => {
         if (event.key === 'z' || event.key === 'Z' || event.key === 'x' || event.key === 'X' || event.key === 'c' || event.key === 'C') return; // Don't trigger zoom when typing
       }
 
-      // Space bar: global play/pause for all armed loop tracks (disabled when text inputs are focused)
+      // Space: Sample Edit = local transport; otherwise global loop play/pause
       if (event.key === ' ') {
-        if (isTypingInput) return; // Ensure we never trigger playback while user is typing
-        if (isTapTempoActive) return; // Let event propagate to TempoControls for tap tempo
+        if (isTypingInput) return;
+        if (isTapTempoActive) return;
         event.preventDefault();
         event.stopPropagation();
-        if (!event.repeat) handleGlobalPlay();
+        if (!event.repeat) {
+          if (sampleEditTrackId) {
+            getTogglePlaybackRef(sampleEditTrackId).current?.();
+          } else {
+            handleGlobalPlay();
+          }
+        }
         return;
       }
 
@@ -1309,20 +1374,23 @@ const Studio = () => {
         return;
       }
 
-      // Zoom shortcuts: z=zoom in, x=zoom out, c=reset (affects first track)
+      // Zoom shortcuts: z=zoom in, x=zoom out, c=reset (edited track in Sample Edit, else first track)
       if (tracks.length > 0) {
-        const activeTrackId = tracks[0].id;
+        const zoomTargetId =
+          sampleEditTrackId && tracks.some((t) => t.id === sampleEditTrackId)
+            ? sampleEditTrackId
+            : tracks[0].id;
         if (event.key === 'z' || event.key === 'Z') {
           event.preventDefault();
-          handleZoomIn(activeTrackId);
+          handleZoomIn(zoomTargetId);
           return;
         } else if (event.key === 'x' || event.key === 'X') {
           event.preventDefault();
-          handleZoomOut(activeTrackId);
+          handleZoomOut(zoomTargetId);
           return;
         } else if (event.key === 'c' || event.key === 'C') {
           event.preventDefault();
-          handleResetZoom(activeTrackId);
+          handleResetZoom(zoomTargetId);
           return;
         }
       }
@@ -1330,7 +1398,7 @@ const Studio = () => {
 
     window.addEventListener('keydown', handleKeyPress, true); // Capture phase: handle Space before focused buttons or default scroll
     return () => window.removeEventListener('keydown', handleKeyPress, true);
-  }, [tracks, currentTrackIndex, isTapTempoActive, handleGlobalPlay]);
+  }, [tracks, currentTrackIndex, isTapTempoActive, handleGlobalPlay, sampleEditTrackId, getTogglePlaybackRef]);
 
         // Handle demo track changes
       useEffect(() => {
@@ -1778,7 +1846,7 @@ const Studio = () => {
       if (assetsLength > 1) {
         historyStackRef.current.push(currentTrackIndex);
       }
-      await loadTrackByIndex(nextIndex, true); // true = only update first track
+      await loadTrackByIndex(nextIndex, { replaceSlotIndex: 0 });
     }
   }, [tracks.length, currentTrackIndex, isTrackLoading, isGuestLoading, isGuestMode, loadRandomGuestTrack, availableAssets, getRandomNextIndex]);
 
@@ -1799,16 +1867,26 @@ const Studio = () => {
         : getRandomNextIndex(assetsLength, currentTrackIndex);
       if (prevIndex === null) return;
 
-      await loadTrackByIndex(prevIndex, true); // true = only update first track
+      await loadTrackByIndex(prevIndex, { replaceSlotIndex: 0 });
     }
   }, [tracks.length, currentTrackIndex, isTrackLoading, isGuestLoading, isGuestMode, loadRandomGuestTrack, availableAssets, getRandomNextIndex]);
 
-  const loadTrackByIndex = async (index: number, onlyUpdateFirstTrack: boolean = false) => {
+  const loadTrackByIndex = async (
+    index: number,
+    replace?: boolean | { replaceSlotIndex: number }
+  ) => {
     const assets = availableAssets || [];
     const safeIndex = ((index % assets.length) + assets.length) % assets.length;
     const asset = assets[safeIndex];
-    
-    if (asset && onlyUpdateFirstTrack && tracks.length > 0) {
+    const replaceSlotIndex =
+      replace === true
+        ? 0
+        : typeof replace === 'object' && replace != null && typeof replace.replaceSlotIndex === 'number'
+          ? replace.replaceSlotIndex
+          : null;
+    const replaceOneSlot = replaceSlotIndex !== null && tracks.length > 0;
+
+    if (asset && replaceOneSlot && replaceSlotIndex! < tracks.length) {
       setLoadingTrackPlaceholder({
         id: `loading-${Date.now()}`,
         displayName: asset.name,
@@ -1861,12 +1939,13 @@ const Studio = () => {
       // Load the audio file into buffer
       const buffer = await loadAudioBuffer(file, context);
       
-      // Generate track ID - preserve existing first track ID if only updating first track
-      let trackId;
-      if (onlyUpdateFirstTrack && tracks.length > 0) {
-        trackId = tracks[0].id; // Keep the existing first track's ID
+      // Generate track ID — preserve existing slot id when replacing one deck
+      let trackId: string;
+      if (replaceOneSlot && tracks.length > 0) {
+        const slot = Math.max(0, Math.min(replaceSlotIndex!, tracks.length - 1));
+        trackId = tracks[slot].id;
       } else {
-        trackId = asset.id; // Use asset ID for new tracks
+        trackId = asset.id;
       }
       
       // Try to load settings from localStorage
@@ -1900,30 +1979,28 @@ const Studio = () => {
         beats: asset.beats
       };
       
-      if (onlyUpdateFirstTrack && tracks.length > 0) {
-        // Only update the first track, preserve other tracks
-        const replacedTrackId = tracks[0].id;
-        setTracks(prevTracks => {
+      if (replaceOneSlot && tracks.length > 0) {
+        const slot = Math.max(0, Math.min(replaceSlotIndex!, tracks.length - 1));
+        const replacedTrackId = tracks[slot].id;
+        setTracks((prevTracks) => {
           const updatedTracks = [...prevTracks];
-          // Update the first track in place to preserve React's reference
-          updatedTracks[0] = {
-            ...updatedTracks[0], // Keep existing properties
-            ...newTrack, // Override with new track data
-            id: updatedTracks[0].id // Ensure we keep the original ID
+          updatedTracks[slot] = {
+            ...updatedTracks[slot],
+            ...newTrack,
+            id: updatedTracks[slot].id,
           };
           return updatedTracks;
         });
-        addingTrackIdRef.current = replacedTrackId; // Defer clearing placeholder until waveform is ready
+        addingTrackIdRef.current = replacedTrackId;
       } else {
-        // Replace all tracks (original behavior)
         setTracks([newTrack]);
-        addingTrackIdRef.current = newTrack.id; // Defer clearing placeholder until waveform is ready
+        addingTrackIdRef.current = newTrack.id;
       }
       setCurrentTrackIndex(safeIndex);
       setShowMeasures(prev => ({ ...prev, [trackId]: !!settings.showMeasures }));
       setShowCueThumbs(prev => ({ ...prev, [trackId]: settings.showCueThumbs !== undefined ? !!settings.showCueThumbs : true }));
       setZoomLevels(prev => ({ ...prev, [trackId]: settings.zoomLevel || 1 }));
-      if (!onlyUpdateFirstTrack) {
+      if (!replaceOneSlot) {
         setSelectedCueTrackId(trackId);
       } else if (newTrack.mode === 'cue') {
         setSelectedCueTrackId(trackId);
@@ -1954,6 +2031,53 @@ const Studio = () => {
       setIsTrackLoading(false);
       setLoadingTrackPlaceholder(null);
     }
+  };
+
+  const handleSampleEditNextLibrary = async () => {
+    if (isTrackLoading || isGuestLoading || !sampleEditTrackId) return;
+    const slot = tracks.findIndex((tr) => tr.id === sampleEditTrackId);
+    if (slot < 0) return;
+    const assetsLength = (availableAssets || []).length;
+    if (assetsLength <= 0) return;
+    const nextIndex = getRandomNextIndex(assetsLength, currentTrackIndex);
+    if (nextIndex === null) return;
+    if (assetsLength > 1) {
+      historyStackRef.current.push(currentTrackIndex);
+    }
+    await loadTrackByIndex(nextIndex, { replaceSlotIndex: slot });
+  };
+
+  const handleSampleEditPrevLibrary = async () => {
+    if (isTrackLoading || isGuestLoading || !sampleEditTrackId) return;
+    const slot = tracks.findIndex((tr) => tr.id === sampleEditTrackId);
+    if (slot < 0) return;
+    const assetsLength = (availableAssets || []).length;
+    if (assetsLength <= 0) return;
+    const prevFromHistory = historyStackRef.current.pop();
+    const prevIndex =
+      typeof prevFromHistory === 'number'
+        ? prevFromHistory
+        : getRandomNextIndex(assetsLength, currentTrackIndex);
+    if (prevIndex === null) return;
+    await loadTrackByIndex(prevIndex, { replaceSlotIndex: slot });
+  };
+
+  const handleSampleEditPrevSessionTrack = () => {
+    if (!sampleEditTrackId || tracks.length < 2) return;
+    const idx = tracks.findIndex((t) => t.id === sampleEditTrackId);
+    if (idx <= 0) return;
+    const nextId = tracks[idx - 1].id;
+    setSampleEditTrackId(nextId);
+    setSelectedCueTrackId(nextId);
+  };
+
+  const handleSampleEditNextSessionTrack = () => {
+    if (!sampleEditTrackId || tracks.length < 2) return;
+    const idx = tracks.findIndex((t) => t.id === sampleEditTrackId);
+    if (idx < 0 || idx >= tracks.length - 1) return;
+    const nextId = tracks[idx + 1].id;
+    setSampleEditTrackId(nextId);
+    setSelectedCueTrackId(nextId);
   };
 
   // Add new track function
@@ -2339,6 +2463,14 @@ const Studio = () => {
 
   // Handle cue point drag state updates for real-time timestamp display
   const handleCueDragStateChange = (trackId: string, index: number, time: number | null) => {
+    logRegionDragTransport('Studio handleCueDragStateChange', {
+      trackId,
+      index,
+      time,
+      sampleEditTrackId,
+      inSampleEdit: sampleEditTrackId === trackId,
+      phase: time === null ? 'drag-end' : 'drag-active',
+    });
     setCueDragStates(prev => {
       const newState = { ...prev };
       const trackState = newState[trackId] ? { ...newState[trackId] } : {};
@@ -2361,6 +2493,14 @@ const Studio = () => {
   };
 
   const handleLoopDragStateChange = (trackId: string, start: number | null, end: number | null) => {
+    logRegionDragTransport('Studio handleLoopDragStateChange', {
+      trackId,
+      start,
+      end,
+      sampleEditTrackId,
+      inSampleEdit: sampleEditTrackId === trackId,
+      phase: start === null || end === null ? 'drag-end' : 'drag-active',
+    });
     setLoopDragStates(prev => {
       if (start === null || end === null) {
         const { [trackId]: _, ...rest } = prev;
@@ -4524,6 +4664,50 @@ const Studio = () => {
               if ((e.target as HTMLElement).closest?.('button, input, select, a, [role=button], [role=slider], .audafact-waveform-bg')) return;
               setSuggestionReferenceTrackId(track.id);
             } : undefined}
+            onDoubleClick={(e) => {
+              if (isGuestMode) return;
+              if (
+                (e.target as HTMLElement).closest?.(
+                  'button, input, select, a, [role=button], [role=slider], .audafact-waveform-bg, textarea'
+                )
+              ) {
+                return;
+              }
+              e.preventDefault();
+              openSampleEditMode(track.id);
+            }}
+            onTouchEnd={(e) => {
+              if (isGuestMode) return;
+              if (
+                (e.target as HTMLElement).closest?.(
+                  'button, input, select, a, [role=button], [role=slider], .audafact-waveform-bg, textarea'
+                )
+              ) {
+                return;
+              }
+              const touch = e.changedTouches[0];
+              if (!touch) return;
+              const now = Date.now();
+              const last = lastTapForSampleEditRef.current;
+              if (
+                last &&
+                last.trackId === track.id &&
+                now - last.t < 380 &&
+                Math.abs(touch.clientX - last.x) < 40 &&
+                Math.abs(touch.clientY - last.y) < 40
+              ) {
+                lastTapForSampleEditRef.current = null;
+                e.preventDefault();
+                openSampleEditMode(track.id);
+                return;
+              }
+              lastTapForSampleEditRef.current = {
+                t: now,
+                x: touch.clientX,
+                y: touch.clientY,
+                trackId: track.id,
+              };
+            }}
             className={`audafact-card overflow-hidden transition-all duration-300 relative ${
               isSuggestionRef
                 ? 'border-audafact-accent-cyan shadow-card' // Suggestion reference track
@@ -4635,6 +4819,21 @@ const Studio = () => {
             </div>
             )}
 
+            {sampleEditTrackId === track.id ? (
+              <div className="border-b border-audafact-divider bg-audafact-surface-1 p-6 text-center">
+                <p className="text-sm audafact-text-secondary">
+                  This deck is open in Sample Edit. Use Back, Escape, or tap outside the editor to return.
+                </p>
+                <button
+                  type="button"
+                  className="mt-3 rounded-lg border border-audafact-divider px-4 py-2 text-sm font-medium text-audafact-text-primary hover:bg-audafact-surface-2"
+                  onClick={() => closeSampleEditMode()}
+                >
+                  Return to Studio
+                </button>
+              </div>
+            ) : (
+            <>
             {/* Track Header */}
             <div className="p-4 border-b border-audafact-divider bg-audafact-surface-1">
               {/* Mobile layout */}
@@ -4978,8 +5177,8 @@ const Studio = () => {
               </div>
             )}
 
-            {/* Waveform Display */}
-            <div className="audafact-waveform-bg relative" style={{ height: '120px' }}>
+            {/* Waveform Display — height comes from WaveformDisplay (shell + optional cue-thumb strip) */}
+            <div className="audafact-waveform-bg relative">
               {loadingTrackPlaceholder && index === 0 && !waveformReadyTrackIds.has(track.id) && (
                 <div className="absolute inset-0 z-50 flex items-center justify-center bg-audafact-waveform-bg" aria-hidden>
                   <div className="flex items-end gap-1 h-12" aria-hidden>
@@ -5066,46 +5265,13 @@ const Studio = () => {
                 trackId={track.id}
                 seekFunctionRef={getSeekFunctionRef(track.id)}
                 togglePlaybackFunctionRef={getTogglePlaybackRef(track.id)}
+                pauseTransportOnRegionDrag={false}
                 recordingDestination={isRecordingPerformance ? getRecordingDestination() : null}
                 cueDragState={cueDragStates[track.id] || null}
                 chopTriggerStyle={track.chopTriggerStyle ?? 'cue'}
+                onChopTriggerStyleChange={(style) => handleChopTriggerStyleChange(track.id, style)}
               />
 
-              {track.mode === 'cue' && (
-                <div className="mt-3 flex flex-wrap items-center gap-2">
-                  <span className="text-xs audafact-text-secondary">Trigger style:</span>
-                  <div className="flex rounded-md border border-audafact-divider p-0.5 bg-audafact-surface-2">
-                    {(['cue', 'hold', 'one-shot'] as const).map((style) => {
-                      const locked = style !== 'cue' && tier.id === 'guest';
-                      return (
-                      <button
-                        key={style}
-                        type="button"
-                        onClick={() => handleChopTriggerStyleChange(track.id, style)}
-                        title={
-                          locked
-                            ? 'Sign up to unlock Hold and One-Shot modes'
-                            : style === 'cue'
-                              ? 'Jump to cue and continue'
-                              : style === 'hold'
-                                ? 'Play while held'
-                                : 'Play slice once'
-                        }
-                        className={`px-2 py-1 text-xs font-medium rounded transition-colors ${
-                          (track.chopTriggerStyle ?? 'cue') === style
-                            ? 'bg-audafact-alert-red text-audafact-text-primary shadow-sm'
-                            : locked
-                              ? 'text-audafact-text-secondary opacity-50 hover:opacity-80'
-                              : 'text-audafact-text-secondary hover:text-audafact-text-primary'
-                        }`}
-                      >
-                        {style === 'one-shot' ? 'One-Shot' : style.charAt(0).toUpperCase() + style.slice(1)}
-                        {locked ? ' 🔒' : ''}
-                      </button>
-                    )})}
-                  </div>
-                </div>
-              )}
               {track.mode === 'cue' && track.id === selectedCueTrackId && (
                 <div className="mt-3 bg-audafact-accent-blue bg-opacity-10 p-2 rounded text-audafact-accent-blue text-xs">
                   Press keyboard keys 1-0 to trigger cue points
@@ -5117,11 +5283,249 @@ const Studio = () => {
                 </div>
               )}
             </div>
+            </>
+            )}
           </div>
           );
         })}
         </div>
       </div>
+
+      {sampleEditTrackId &&
+        (() => {
+          const editIndex = tracks.findIndex((t) => t.id === sampleEditTrackId);
+          if (editIndex < 0) return null;
+          const track = tracks[editIndex];
+          return (
+            <SampleEditMode
+              sessionTrackId={track.id}
+              trackLabel={track.file.name}
+              onClose={closeSampleEditMode}
+              onPrevLibrary={() => void handleSampleEditPrevLibrary()}
+              onNextLibrary={() => void handleSampleEditNextLibrary()}
+              onPrevSessionTrack={handleSampleEditPrevSessionTrack}
+              onNextSessionTrack={handleSampleEditNextSessionTrack}
+              hasPrevSessionTrack={editIndex > 0}
+              hasNextSessionTrack={editIndex < tracks.length - 1}
+              isTrackLoading={isTrackLoading}
+            >
+              <div className="border-b border-audafact-divider bg-audafact-surface-2 px-3 py-2 sm:px-4">
+                <div className="flex min-w-0 flex-nowrap items-center justify-between gap-2 sm:gap-3">
+                  <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
+                    <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide text-audafact-text-secondary sm:text-xs sm:normal-case sm:tracking-normal">
+                      Mode
+                    </span>
+                    {/* Match desktop deck track card: compact flex segment, intrinsic width */}
+                    <div className="flex items-center rounded-md border border-audafact-divider bg-audafact-surface-2 p-0.5">
+                      <button
+                        type="button"
+                        disabled={editIndex !== 0}
+                        title={
+                          editIndex !== 0
+                            ? 'Only the top deck can use Preview mode'
+                            : 'Preview — full track'
+                        }
+                        onClick={() => editIndex === 0 && handleModeChange(track.id, 'preview')}
+                        className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
+                          track.mode === 'preview'
+                            ? 'bg-audafact-accent-blue text-audafact-text-primary shadow-sm'
+                            : editIndex !== 0
+                              ? 'cursor-not-allowed text-audafact-text-secondary opacity-50'
+                              : 'text-audafact-text-secondary hover:text-audafact-text-primary'
+                        }`}
+                        data-testid="sample-edit-preview-mode-button"
+                      >
+                        Preview
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleModeChange(track.id, 'loop')}
+                        className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
+                          track.mode === 'loop'
+                            ? 'bg-audafact-accent-cyan text-audafact-bg-primary shadow-sm'
+                            : 'text-audafact-text-secondary hover:text-audafact-text-primary'
+                        }`}
+                        data-testid="sample-edit-loop-mode-button"
+                      >
+                        Loop
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleModeChange(track.id, 'cue')}
+                        className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
+                          track.mode === 'cue'
+                            ? 'bg-audafact-alert-red text-audafact-text-primary shadow-sm'
+                            : 'text-audafact-text-secondary hover:text-audafact-text-primary'
+                        }`}
+                        data-testid="sample-edit-chop-mode-button"
+                      >
+                        Chop
+                      </button>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleToggleControls(track.id)}
+                    className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-audafact-divider bg-audafact-surface-1 px-2 py-1.5 text-left text-[11px] font-medium text-audafact-text-secondary hover:bg-audafact-surface-2 sm:px-3 sm:text-xs"
+                    title={expandedControls[track.id] ? 'Collapse Controls' : 'Expand Controls'}
+                    data-testid="sample-edit-time-tempo-controls-button"
+                  >
+                    <span className="whitespace-nowrap">Time & Tempo</span>
+                    <svg
+                      className={`h-3 w-3 shrink-0 transition-transform ${expandedControls[track.id] ? 'rotate-180' : ''}`}
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </button>
+                </div>
+                {expandedControls[track.id] && (
+                  <div className="mt-3 space-y-4 border-t border-audafact-divider pt-3">
+                    <div className="space-y-2">
+                      <TempoControls
+                        trackId={track.id}
+                        initialTempo={track.tempo}
+                        onTempoChange={handleTempoChange}
+                        playbackSpeed={playbackSpeeds[track.id] || 1}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <TimeSignatureControls
+                        timeSignature={track.timeSignature}
+                        onTimeSignatureChange={(timeSignature) =>
+                          handleTimeSignatureChange(track.id, timeSignature)
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+              <div className="audafact-waveform-bg relative">
+                {loadingTrackPlaceholder && editIndex === 0 && !waveformReadyTrackIds.has(track.id) && (
+                  <div
+                    className="absolute inset-0 z-50 flex items-center justify-center bg-audafact-waveform-bg"
+                    aria-hidden
+                  >
+                    <div className="flex h-12 items-end gap-1" aria-hidden>
+                      {[...Array(24)].map((_, i) => (
+                        <div
+                          key={i}
+                          className="w-1 rounded-sm bg-audafact-accent-cyan/30 animate-pulse"
+                          style={{
+                            height: `${20 + Math.sin(i * 0.5) * 30}%`,
+                            animationDelay: `${i * 50}ms`,
+                          }}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                )}
+                <WaveformDisplay
+                  audioFile={track.file}
+                  peaks={track.peaks}
+                  duration={track.peaks ? track.buffer.duration : undefined}
+                  scrubAudioBuffer={track.buffer}
+                  ensureAudioForScrub={ensureAudioBeforeAction}
+                  mode={track.mode}
+                  loopStart={track.loopStart}
+                  loopEnd={track.loopEnd}
+                  cuePoints={track.cuePoints}
+                  onLoopPointsChange={(start, end) => handleLoopPointsChange(track.id, start, end)}
+                  onLoopDragStateChange={(start, end) => handleLoopDragStateChange(track.id, start, end)}
+                  onCuePointChange={(ci, time) => handleCuePointChange(track.id, ci, time)}
+                  playhead={track.mode === 'loop' ? loopPlayhead : samplePlayhead}
+                  playbackTime={playbackTimes[track.id] || 0}
+                  zoomLevel={zoomLevels[track.id] || 1}
+                  onZoomIn={() => handleZoomIn(track.id)}
+                  onZoomOut={() => handleZoomOut(track.id)}
+                  onResetZoom={() => handleResetZoom(track.id)}
+                  onZoomChange={(level) => handleZoomChange(track.id, level)}
+                  trackId={track.id}
+                  showMeasures={showMeasures[track.id]}
+                  tempo={track.tempo}
+                  timeSignature={track.timeSignature}
+                  firstMeasureTime={track.firstMeasureTime}
+                  onFirstMeasureChange={(time) => handleFirstMeasureChange(track.id, time)}
+                  showCueThumbs={(showCueThumbs[track.id] ?? true)}
+                  isPlaying={playbackStates[track.id] || false}
+                  onPlayheadChange={(time) => handlePlayheadChange(track.id, time)}
+                  onScrollStateChange={(isScrolling) => handleWaveformScrollStateChange(track.id, isScrolling)}
+                  isGuestMode={isGuestMode}
+                  chopTriggerStyle={track.chopTriggerStyle ?? 'cue'}
+                  onCueDragStateChange={(ci, time) => handleCueDragStateChange(track.id, ci, time)}
+                  onReady={() => handleWaveformReady(track.id)}
+                  suppressLoadingOverlay={
+                    !!(loadingTrackPlaceholder && editIndex === 0 && !waveformReadyTrackIds.has(track.id))
+                  }
+                  beats={track.beats}
+                  cueDragTime={
+                    cueDragStates[track.id] ? (Object.values(cueDragStates[track.id])[0] ?? null) : null
+                  }
+                  suspendTransportOnRegionDragStart={() =>
+                    getSuspendTransportForRegionDragSyncRef(track.id).current?.()
+                  }
+                />
+              </div>
+              <div className="relative z-10 bg-audafact-surface-1 p-4">
+                <TrackControls
+                  key={`sample-edit-controls-${track.id}`}
+                  mode={track.mode}
+                  audioContext={audioContext}
+                  audioBuffer={track.buffer}
+                  loopStart={track.loopStart}
+                  loopEnd={track.loopEnd}
+                  loopDragState={loopDragStates[track.id] || null}
+                  cuePoints={track.cuePoints}
+                  ensureAudio={ensureAudioBeforeAction}
+                  primeIosSessionForWebAudio={primeIosSessionForWebAudio}
+                  isSelected={track.id === selectedCueTrackId}
+                  onSelect={() => handleTrackSelect(track.id)}
+                  onPlaybackTimeChange={(time) => handlePlaybackTimeChange(track.id, time)}
+                  onSpeedChange={(speed) => handleSpeedChange(track.id, speed)}
+                  trackTempo={track.tempo}
+                  volume={volume[track.id] || 1}
+                  onVolumeChange={(newVolume) => handleVolumeChange(track.id, newVolume)}
+                  playbackSpeed={playbackSpeeds[track.id] || 1}
+                  onPlaybackStateChange={(isPlaying: boolean) =>
+                    handlePlaybackStateChange(track.id, isPlaying)
+                  }
+                  playbackTime={playbackTimes[track.id] || 0}
+                  disabled={false}
+                  lowpassFreq={lowpassFreqs[track.id] || 20000}
+                  onLowpassFreqChange={(freq) => handleLowpassFreqChange(track.id, freq)}
+                  highpassFreq={highpassFreqs[track.id] || 20}
+                  onHighpassFreqChange={(freq) => handleHighpassFreqChange(track.id, freq)}
+                  filterEnabled={filterEnabled[track.id] || false}
+                  onFilterEnabledChange={(enabled) => handleFilterEnabledChange(track.id, enabled)}
+                  showDeleteButton={tracks.length > 1 && track.mode !== 'preview'}
+                  onDelete={() => removeTrack(track.id)}
+                  trackId={track.id}
+                  seekFunctionRef={getSeekFunctionRef(track.id)}
+                  togglePlaybackFunctionRef={getTogglePlaybackRef(track.id)}
+                  suspendTransportForRegionDragSyncRef={getSuspendTransportForRegionDragSyncRef(track.id)}
+                  pauseTransportOnRegionDrag
+                  recordingDestination={isRecordingPerformance ? getRecordingDestination() : null}
+                  cueDragState={cueDragStates[track.id] || null}
+                  chopTriggerStyle={track.chopTriggerStyle ?? 'cue'}
+                  onChopTriggerStyleChange={(style) => handleChopTriggerStyleChange(track.id, style)}
+                />
+                {track.mode === 'cue' && track.id === selectedCueTrackId && (
+                  <div className="mt-3 rounded bg-audafact-accent-blue bg-opacity-10 p-2 text-xs text-audafact-accent-blue">
+                    Press 1–0 to trigger cues (Sample Edit — local transport)
+                  </div>
+                )}
+                {track.mode === 'loop' && (
+                  <div className="mt-3 rounded bg-audafact-accent-cyan bg-opacity-10 p-2 text-xs text-audafact-accent-cyan">
+                    Space: play/pause this loop (Sample Edit)
+                  </div>
+                )}
+              </div>
+            </SampleEditMode>
+          );
+        })()}
 
       {/* Signup Modal */}
       {showEarlyCreatorModal && (


### PR DESCRIPTION
Main deck keeps Web Audio running while dragging loop/cue handles so the performance layer is not interrupted. Sample Edit wires suspend/resume and scrub again so the editor owns transport. TrackControls gains an optional pauseTransportOnRegionDrag flag and resume-at-pause after drag when pausing.

Also adds Sample Edit shell, optional region-drag diagnostics, shared user profile fetch for hooks, and waveform scrub diagnostics utilities.

Made-with: Cursor