### PR TITLE
Fix pre-login restore regression after auth transition.

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -5,6 +5,7 @@ import { authService, AuthResponse } from '../auth/authService';
 import { analytics } from '../services/analyticsService';
 import { IntentManagementService } from '../services/intentManagementService';
 import { PostSignupFlowHandler } from '../services/postSignupFlowHandler';
+import { DemoSessionManager } from '../services/demoSessionManager';
 
 interface AuthContextType {
   user: User | null;
@@ -36,6 +37,10 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   useEffect(() => {
     // Get initial session
     supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.user) {
+        // Support redirect-based auth flows where INITIAL_SESSION hydrates without a SIGNED_IN event.
+        DemoSessionManager.getInstance().migrateGuestSnapshotToUser(session.user.id);
+      }
       setUser(session?.user ?? null);
       setLoading(false);
       

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,16 +12,34 @@ export function getApiBase(): string {
 const signFileRetryDelay = 2000;
 /** Signed URLs from Worker are valid 90s; cache for 75s to avoid using expired URLs */
 const SIGNED_URL_CACHE_TTL_MS = 75_000;
+const AUTH_RECOVERY_RETRY_DELAY_MS = 250;
 
 // Cache: key -> { url, expiresAt }
 const signedUrlCache = new Map<string, { url: string; expiresAt: number }>();
 // Coalesce in-flight requests: key -> Promise<string>
 const signFileInFlight = new Map<string, Promise<string>>();
 
-async function signFileInternal(key: string, retryCount: number): Promise<string> {
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function resolveAccessTokenForApi(): Promise<string | null> {
   const sessionResult = await supabase.auth.getSession();
-  const { data: s } = sessionResult || {};
-  const token = s?.session?.access_token;
+  const token = sessionResult?.data?.session?.access_token;
+  if (token) return token;
+
+  // During auth transitions (guest -> signed-in), session hydration may lag briefly.
+  const refreshed = await supabase.auth.refreshSession();
+  const refreshedToken = refreshed?.data?.session?.access_token;
+  if (refreshedToken) return refreshedToken;
+
+  await sleep(AUTH_RECOVERY_RETRY_DELAY_MS);
+  const retryResult = await supabase.auth.getSession();
+  return retryResult?.data?.session?.access_token ?? null;
+}
+
+async function signFileInternal(key: string, retryCount: number): Promise<string> {
+  const token = await resolveAccessTokenForApi();
   if (!token) throw new Error("Not signed in");
 
   const base = getApiBase();
@@ -43,10 +61,9 @@ async function signFileInternal(key: string, retryCount: number): Promise<string
 
   let r = await requestWithToken(token);
   if (r.status === 401) {
-    const refreshed = await supabase.auth.refreshSession();
-    const refreshedToken = refreshed?.data?.session?.access_token;
-    if (refreshedToken) {
-      r = await requestWithToken(refreshedToken);
+    const recoveredToken = await resolveAccessTokenForApi();
+    if (recoveredToken && recoveredToken !== token) {
+      r = await requestWithToken(recoveredToken);
     }
   }
 
@@ -112,8 +129,7 @@ export async function fetchLibraryAudioBlob(
   fileKey: string,
   retryCount = 0
 ): Promise<Blob> {
-  const sessionResult = await supabase.auth.getSession();
-  const token = sessionResult?.data?.session?.access_token;
+  const token = await resolveAccessTokenForApi();
   if (!token) throw new Error("Not signed in");
 
   const base = getApiBase();
@@ -135,10 +151,9 @@ export async function fetchLibraryAudioBlob(
 
   let r = await requestWithToken(token);
   if (r.status === 401) {
-    const refreshed = await supabase.auth.refreshSession();
-    const refreshedToken = refreshed?.data?.session?.access_token;
-    if (refreshedToken) {
-      r = await requestWithToken(refreshedToken);
+    const recoveredToken = await resolveAccessTokenForApi();
+    if (recoveredToken && recoveredToken !== token) {
+      r = await requestWithToken(recoveredToken);
     }
   }
 

--- a/src/services/demoSessionManager.ts
+++ b/src/services/demoSessionManager.ts
@@ -16,11 +16,6 @@ export class DemoSessionManager {
 
   migrateGuestSnapshotToUser(userId: string): boolean {
     try {
-      const alreadyRestoredForUser = localStorage.getItem(PRELOGIN_TRANSITION_RESTORED_KEY);
-      if (alreadyRestoredForUser === userId) {
-        localStorage.removeItem(PRELOGIN_TRANSITION_PENDING_KEY);
-        return false;
-      }
       const raw = localStorage.getItem(PRELOGIN_TRANSITION_SNAPSHOT_KEY);
       if (!raw) return false;
       const parsed = JSON.parse(raw) as { expiresAt?: number };

--- a/src/views/Studio.tsx
+++ b/src/views/Studio.tsx
@@ -1412,7 +1412,8 @@ const Studio = () => {
       const genAiAsset = pair.genAiAsset;
 
       const fetchGuidedAudioBlob = async (assetPath: string, assetLabel: string): Promise<Blob> => {
-        const baseUrl = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+        const env = import.meta.env as unknown as Record<string, string | undefined>;
+        const baseUrl = (env.BASE_URL || '/').replace(/\/$/, '');
         const candidates = assetPath.startsWith('/')
           ? [assetPath, `${baseUrl}${assetPath}`]
           : [assetPath];
@@ -1738,6 +1739,10 @@ const Studio = () => {
     if (signedInRandomLoadStartedRef.current) return;
 
     if (isGuestMode) {
+      // During auth/session hydration, avoid booting guest tracks too early.
+      // If guest track bootstrap wins this race, restore is blocked by tracks.length > 0.
+      if (authLoading || userLoading) return;
+      if (localStorage.getItem(PRELOGIN_TRANSITION_PENDING_KEY)) return;
       signedInRandomLoadStartedRef.current = true;
       void loadRandomTrack();
       return;


### PR DESCRIPTION
Ensure guest transition snapshots are migrated on initial session hydration, allow fresh snapshot migration per login, and harden protected audio token recovery so signed-in restore no longer falls back to repeated demo pair bootstrap.

Made-with: Cursor