### PR TITLE
Update live Stripe IDs for production checkout

### DIFF
--- a/config/environments.ts
+++ b/config/environments.ts
@@ -111,12 +111,12 @@ export const stripeConfig = {
     priceEarlyAdopter: "price_test_early_adopter",
   },
   live: {
-    productMonthly: "prod_live_monthly",
-    productYearly: "prod_live_yearly",
-    productEarlyAdopter: "prod_live_early_adopter",
-    priceMonthly: "price_live_monthly",
-    priceYearly: "price_live_yearly",
-    priceEarlyAdopter: "price_live_early_adopter",
+    productMonthly: "prod_Sn60Kc8AJAZ8bB",
+    productYearly: "prod_Sn619yLYhrvho1",
+    productEarlyAdopter: "prod_Sn615MTOdI4Aid",
+    priceMonthly: "price_1RrVoUFXfkCegelfDVGstIQj",
+    priceYearly: "price_1RrVpRFXfkCegelfhCMU5hpc",
+    priceEarlyAdopter: "price_1RrVpqFXfkCegelfKnAoG0T4",
   },
 };
 

--- a/config/production.json
+++ b/config/production.json
@@ -15,13 +15,13 @@
   "r2AccountId": "829b50f2f5c67ed26ec5cc89af772064",
   "r2Bucket": "audafact",
   "stripeProducts": {
-    "monthly": "prod_live_monthly",
-    "yearly": "prod_live_yearly",
-    "earlyAdopter": "prod_live_early_adopter"
+    "monthly": "prod_Sn60Kc8AJAZ8bB",
+    "yearly": "prod_Sn619yLYhrvho1",
+    "earlyAdopter": "prod_Sn615MTOdI4Aid"
   },
   "stripePrices": {
-    "monthly": "price_live_monthly",
-    "yearly": "price_live_yearly",
-    "earlyAdopter": "price_live_early_adopter"
+    "monthly": "price_1RrVoUFXfkCegelfDVGstIQj",
+    "yearly": "price_1RrVpRFXfkCegelfhCMU5hpc",
+    "earlyAdopter": "price_1RrVpqFXfkCegelfKnAoG0T4"
   }
 }


### PR DESCRIPTION
## Summary
- replace placeholder live Stripe product IDs in `config/environments.ts` with real live IDs
- replace placeholder live Stripe product and price IDs in `config/production.json` with real live IDs
- align production fallbacks so checkout sends valid live-mode `price_...` values

## Test plan
- [ ] Deploy this branch to production build pipeline
- [ ] Trigger checkout from pricing page and confirm request payload sends real `price_...` IDs
- [ ] Verify Stripe checkout session is created successfully in live mode

Made with [Cursor](https://cursor.com)