### PR TITLE
Pass Stripe live vars into production frontend build

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -40,6 +40,14 @@ jobs:
           VITE_APP_ENV: production
           # Ignore any repo .env / machine VITE_API_BASE_URL; use config/production.json (+ /api) via vite.config.js
           VITE_API_BASE_URL: ""
+          # Explicitly pass Stripe identifiers from GitHub Variables so CI builds
+          # do not fall back to placeholder defaults from vite.config.js.
+          VITE_STRIPE_LIVE_PRODUCT_MONTHLY: ${{ vars.VITE_STRIPE_LIVE_PRODUCT_MONTHLY }}
+          VITE_STRIPE_LIVE_PRODUCT_YEARLY: ${{ vars.VITE_STRIPE_LIVE_PRODUCT_YEARLY }}
+          VITE_STRIPE_LIVE_PRODUCT_EARLY_ADOPTER: ${{ vars.VITE_STRIPE_LIVE_PRODUCT_EARLY_ADOPTER }}
+          VITE_STRIPE_LIVE_PRICE_MONTHLY: ${{ vars.VITE_STRIPE_LIVE_PRICE_MONTHLY }}
+          VITE_STRIPE_LIVE_PRICE_YEARLY: ${{ vars.VITE_STRIPE_LIVE_PRICE_YEARLY }}
+          VITE_STRIPE_LIVE_PRICE_EARLY_ADOPTER: ${{ vars.VITE_STRIPE_LIVE_PRICE_EARLY_ADOPTER }}
 
       - name: Deploy to Cloudflare Pages
         run: wrangler pages deploy dist --project-name=audafact-web-prod --branch main


### PR DESCRIPTION
## Summary
- map `VITE_STRIPE_LIVE_*` GitHub Variables into the production build step env in the frontend deploy workflow
- prevent CI builds from falling back to placeholder values like `price_live_monthly` when local `.env` is unavailable
- keep production Stripe ID injection explicit and deterministic for GitHub Actions deployments

## Test plan
- [ ] Ensure repository variables are set for all `VITE_STRIPE_LIVE_*` keys referenced in this workflow
- [ ] Merge PR and run production deploy workflow
- [ ] Verify checkout payload includes real `price_...` values and Stripe session creation succeeds

Made with [Cursor](https://cursor.com)